### PR TITLE
Update README demo invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Configurable delay factory (one distribution per `activity_type`):
 
 ```bash
 pip install plotly
-python -m mc_dagprop.utils.demo_distributions
+python -m mc_dagprop.utils.demonstration
 ```
 
 Displays histograms of realized times and delays.


### PR DESCRIPTION
## Summary
- use new demonstration module in README instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853cd8cffa483228ff135c6bbcd46bd