### PR TITLE
Fix docstring typo

### DIFF
--- a/mc_dagprop/_core.pyi
+++ b/mc_dagprop/_core.pyi
@@ -43,7 +43,7 @@ class SimActivity:
 
 class SimContext:
     """
-    Wraps the DAG: a list of events, a map of activities, a precedence list, and a max?delay.
+    Wraps the DAG: a list of events, a map of activities, a precedence list, and a max_delay.
     """
 
     events: Sequence[SimEvent]


### PR DESCRIPTION
## Summary
- correct the `SimContext` docstring to reference `max_delay`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853cd80c97083229020e44960cc5afc