### PR TITLE
Fix propagation test comment

### DIFF
--- a/test/test_simulator.py
+++ b/test/test_simulator.py
@@ -91,7 +91,7 @@ class TestSimulator(unittest.TestCase):
         # run with a single event
         res = sim.run_many(tuple(range(5)))[3]
 
-        # check that the durations are all 0
+        # check that the durations match the expected values
         self.assertEqual(res.durations[0], 6.0)
         self.assertEqual(res.durations[1], 10.0)
         self.assertEqual(res.durations[2], 10.0)


### PR DESCRIPTION
## Summary
- fix comment in test_propagation to clarify durations check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853cd95e09883228c3958107f7b01aa