### PR TITLE
Add Linux pipeline script

### DIFF
--- a/pipeline.bat
+++ b/pipeline.bat
@@ -17,4 +17,4 @@ call pip install plotly || exit /b
 
 call python mc_dagprop\utils\demonstration.py || exit /b
 
-python test\test_simulator.py || exit /b
+python -m unittest discover -s test -p "*.py" || exit /b

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Delete old build artifacts
+rm -f dist/*
+rm -f build/*
+
+poetry build
+
+for f in dist/mc_dagprop*.whl; do
+    pip install "$f" --force-reinstall
+done
+
+pip install plotly
+
+python -m unittest discover -s test -p "*.py"
+


### PR DESCRIPTION
## Summary
- add pipeline.sh for Linux
- update Windows script to run tests via unittest

## Testing
- `python -m unittest discover -s test -p "*.py"` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853d2ed7f14832290beaff05855485c