### PR TITLE
Fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ which promotes innovative studies in transport management and the future of mobi
 
 ```bash
 # with poetry
-poetry add mc_dagprop
+poetry add mc-dagprop
 
 # or with pip
-pip install mc_dagprop
+pip install mc-dagprop
 ```
 
 ---
@@ -131,8 +131,8 @@ Represents an edge in the DAG:
 
 Container for your DAG:
 
-- `events`:          `List[SimEvent]`  
-- `activities`:      `Dict[(src_idx, dst_idx), SimActivity]`
+- `events`:          `List[SimEvent]`
+- `activities`:      `Dict[(src_idx, dst_idx), (link_idx, SimActivity)]`
 - `precedence_list`: `List[(target_idx, [(pred_idx, link_idx), …])]`
 - `max_delay`:       overall cap on delay propagation
   - Can be given in any order. `Simulator` will sort topologically and raise

--- a/mc_dagprop/_core.pyi
+++ b/mc_dagprop/_core.pyi
@@ -72,7 +72,8 @@ class SimResult:
 
 class GenericDelayGenerator:
     """
-    Configurable delay generator: constant or exponential per activity_type.
+    Configurable delay generator. Supports per-``activity_type`` distributions:
+    constant, exponential, gamma, and empirical (absolute or relative).
     """
 
     def __init__(self) -> None: ...


### PR DESCRIPTION
## Summary
- fix README install command and fix SimContext activities doc
- clarify GenericDelayGenerator docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853d38a7ec483229e9f2f4c57b6e877