### PR TITLE
Update pipeline scripts for plotly dependency

### DIFF
--- a/pipeline.bat
+++ b/pipeline.bat
@@ -9,11 +9,7 @@ del /q build\*.*
 
 call poetry build || exit /b
 
-for %%f in (dist\mc_dagprop*.whl) do (
-    call pip install "%%f" --force-reinstall || exit /b
-)
-
-call pip install plotly || exit /b
+call pip install dist\mc_dagprop*.whl --force-reinstall || exit /b
 
 call python mc_dagprop\utils\demonstration.py || exit /b
 

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -5,13 +5,10 @@ set -euo pipefail
 rm -f dist/*
 rm -f build/*
 
+
 poetry build
 
-for f in dist/mc_dagprop*.whl; do
-    pip install "$f" --force-reinstall
-done
-
-pip install plotly
+pip install dist/mc_dagprop*.whl --force-reinstall
 
 python test/test_simulator.py
 


### PR DESCRIPTION
## Summary
- remove redundant install of plotly from pipeline scripts
- use `pip install dist/mc_dagprop*.whl` to install built wheel

## Testing
- `python test/test_simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6854472723308322be4ac1f82cd8ca04