### PR TITLE
Make plotly optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Configurable delay factory (one distribution per `activity_type`):
 ## Visualization Demo
 
 ```bash
-pip install plotly
+pip install mc-dagprop[plot]
 python -m mc_dagprop.utils.demonstration
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,9 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 numpy = "^2.0.0"
-plotly = "^6.0.0"
 
+[tool.poetry.extras]
+plot = ["plotly"]
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"


### PR DESCRIPTION
## Summary
- remove `plotly` from poetry dependencies
- add extras group for `plot`
- update README instructions for visualization demo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854471c162083228a0315f37b5b9aa3