### PR TITLE
Add discrete PMF analytic simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ Configurable delay factory (one distribution per `activity_type`):
 - `.durations`:  `NDArray[float]` – per-edge durations (base + extra)  
 - `.cause_event`: `NDArray[int]` – which predecessor caused each event  
 
+## Discrete Simulator
+
+You can propagate discrete delay distributions analytically using `DiscreteSimulator`.
+Define per-edge probability mass functions and build an `AnalyticContext`:
+
+```python
+from mc_dagprop import AnalyticContext, DiscretePMF, DiscreteSimulator, EventTimestamp, SimEvent
+
+events = [SimEvent("A", EventTimestamp(0, 10, 0)), SimEvent("B", EventTimestamp(0, 10, 0))]
+activities = {(0, 1): (0, DiscretePMF([1.0, 2.0], [0.5, 0.5]))}
+precedence = [(1, [(0, 0)])]
+ctx = AnalyticContext(events=events, activities=activities, precedence_list=precedence)
+
+sim = DiscreteSimulator(ctx)
+pmfs = sim.run()
+print(pmfs[1].values, pmfs[1].probs)
+```
+This computes event-time PMFs deterministically without Monte-Carlo sampling.
+
+
 ---
 
 ## Visualization Demo

--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import version
 
 from ._core import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, SimResult, Simulator
+from .discrete import AnalyticContext, DiscretePMF, DiscreteSimulator
 from .utils.inspection import plot_activity_delays, retrieve_absolute_and_relative_delays
 
 __version__ = version("mc-dagprop")
@@ -13,6 +14,9 @@ __all__ = [
     "SimActivity",
     "Simulator",
     "EventTimestamp",
+    "DiscretePMF",
+    "AnalyticContext",
+    "DiscreteSimulator",
     "plot_activity_delays",
     "retrieve_absolute_and_relative_delays",
     "__version__",

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -1,0 +1,5 @@
+from .pmf import DiscretePMF
+from .context import AnalyticContext
+from .simulator import DiscreteSimulator
+
+__all__ = ["DiscretePMF", "AnalyticContext", "DiscreteSimulator"]

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from mc_dagprop import SimEvent
+
+from .pmf import DiscretePMF
+
+NodeIndex = int
+EdgeIndex = int
+Pred = Tuple[NodeIndex, EdgeIndex]
+
+
+@dataclass
+class AnalyticEdge:
+    pmf: DiscretePMF
+
+
+@dataclass
+class AnalyticContext:
+    events: List[SimEvent]
+    activities: Dict[Tuple[NodeIndex, NodeIndex], Tuple[EdgeIndex, AnalyticEdge]]
+    precedence_list: List[Tuple[NodeIndex, List[Pred]]]
+    max_delay: float = 0.0

--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+
+@dataclass
+class DiscretePMF:
+    """Simple probability mass function on an equidistant grid."""
+
+    values: np.ndarray
+    probs: np.ndarray
+
+    def __post_init__(self) -> None:
+        if len(self.values) != len(self.probs):
+            raise ValueError("values and probs must have same length")
+        if not np.isclose(self.probs.sum(), 1.0):
+            self.probs = self.probs / self.probs.sum()
+        order = np.argsort(self.values)
+        self.values = self.values[order]
+        self.probs = self.probs[order]
+        # merge identical values
+        uniq, indices = np.unique(self.values, return_inverse=True)
+        if len(uniq) != len(self.values):
+            agg = np.zeros_like(uniq, dtype=float)
+            np.add.at(agg, indices, self.probs)
+            self.values = uniq
+            self.probs = agg
+
+    @property
+    def step(self) -> float:
+        if len(self.values) < 2:
+            return 0.0
+        diffs = np.diff(self.values)
+        return float(diffs[0]) if np.allclose(diffs, diffs[0]) else 0.0
+
+    @staticmethod
+    def delta(v: float) -> "DiscretePMF":
+        return DiscretePMF(np.array([v], dtype=float), np.array([1.0], dtype=float))
+
+    def shift(self, delta: float) -> "DiscretePMF":
+        return DiscretePMF(self.values + delta, self.probs.copy())
+
+    def convolve(self, other: "DiscretePMF") -> "DiscretePMF":
+        if len(self.values) == 1 and len(other.values) == 1:
+            return DiscretePMF.delta(self.values[0] + other.values[0])
+
+        step = self.step or other.step
+        if step and np.isclose(step, other.step) and np.isclose(step, self.step):
+            start = self.values[0] + other.values[0]
+            probs = np.convolve(self.probs, other.probs)
+            values = start + step * np.arange(len(probs))
+            return DiscretePMF(values, probs)
+
+        # fallback: pairwise addition
+        vals = self.values[:, None] + other.values[None, :]
+        probs = self.probs[:, None] * other.probs[None, :]
+        return DiscretePMF(vals.ravel(), probs.ravel())
+
+    def cdf(self) -> np.ndarray:
+        return np.cumsum(self.probs)
+
+    def pmf_from_cdf(self, cdf: np.ndarray) -> "DiscretePMF":
+        probs = np.diff(np.concatenate([[0.0], cdf]))
+        return DiscretePMF(self.values.copy(), probs)
+
+    def maximum(self, other: "DiscretePMF") -> "DiscretePMF":
+        # compute via CDFs: F_max(x) = F1(x) * F2(x)
+        all_vals = np.union1d(self.values, other.values)
+        cdf1 = np.interp(all_vals, self.values, self.cdf(), left=0.0, right=1.0)
+        cdf2 = np.interp(all_vals, other.values, other.cdf(), left=0.0, right=1.0)
+        cdf_max = cdf1 * cdf2
+        return DiscretePMF(all_vals, np.diff(np.concatenate([[0.0], cdf_max])))
+
+    def minimum(self, other: "DiscretePMF") -> "DiscretePMF":
+        # F_min(x) = 1 - (1-F1(x))*(1-F2(x))
+        all_vals = np.union1d(self.values, other.values)
+        cdf1 = np.interp(all_vals, self.values, self.cdf(), left=0.0, right=1.0)
+        cdf2 = np.interp(all_vals, other.values, other.cdf(), left=0.0, right=1.0)
+        cdf_min = 1.0 - (1.0 - cdf1) * (1.0 - cdf2)
+        return DiscretePMF(all_vals, np.diff(np.concatenate([[0.0], cdf_min])))
+
+    def truncate_right(self, max_value: float) -> "DiscretePMF":
+        if max_value >= self.values[-1]:
+            return self
+        idx = np.searchsorted(self.values, max_value, side="right") - 1
+        new_vals = self.values[: idx + 1]
+        new_probs = self.probs[: idx + 1]
+        overflow = self.probs[idx + 1 :].sum()
+        new_probs[-1] += overflow
+        return DiscretePMF(new_vals, new_probs)

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import List
+
+from .context import AnalyticContext
+from .pmf import DiscretePMF
+
+
+class DiscreteSimulator:
+    """Propagate discrete PMFs through a DAG."""
+
+    def __init__(self, context: AnalyticContext):
+        self.context = context
+        self._build_topology()
+
+    def _build_topology(self) -> None:
+        event_count = len(self.context.events)
+        adjacency = [[] for _ in range(event_count)]
+        indegree = [0] * event_count
+        preds_by_target = [None] * event_count
+        for tgt, preds in self.context.precedence_list:
+            preds_by_target[tgt] = preds
+            indegree[tgt] = len(preds)
+            for src, _ in preds:
+                adjacency[src].append(tgt)
+        order: List[int] = []
+        q = deque(i for i, deg in enumerate(indegree) if deg == 0)
+        while q:
+            n = q.popleft()
+            order.append(n)
+            for dst in adjacency[n]:
+                indegree[dst] -= 1
+                if indegree[dst] == 0:
+                    q.append(dst)
+        if len(order) != event_count:
+            raise RuntimeError("Invalid DAG: cycle detected")
+        self._preds_by_target = preds_by_target
+        self.order = order
+
+    def run(self) -> List[DiscretePMF]:
+        event_pmfs: List[DiscretePMF] = [None] * len(self.context.events)  # type: ignore
+        for idx in self.order:
+            ev = self.context.events[idx]
+            base = DiscretePMF.delta(ev.timestamp.earliest)
+            preds = self._preds_by_target[idx]
+            if preds is None:
+                event_pmfs[idx] = base
+                continue
+            cur = None
+            for src, link in preds:
+                edge_pmf = self.context.activities[(src, idx)][1].pmf
+                candidate = event_pmfs[src].convolve(edge_pmf)
+                cur = candidate if cur is None else cur.maximum(candidate)
+            event_pmfs[idx] = cur if cur is not None else base
+        return event_pmfs

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -1,0 +1,60 @@
+import unittest
+import numpy as np
+
+from mc_dagprop import (
+    AnalyticContext,
+    DiscretePMF,
+    DiscreteSimulator,
+    EventTimestamp,
+    GenericDelayGenerator,
+    SimActivity,
+    SimContext,
+    SimEvent,
+    Simulator,
+)
+from mc_dagprop.discrete.context import AnalyticEdge
+
+
+class TestDiscreteSimulator(unittest.TestCase):
+    def setUp(self) -> None:
+        self.events = [
+            SimEvent("0", EventTimestamp(0.0, 100.0, 0.0)),
+            SimEvent("1", EventTimestamp(0.0, 100.0, 0.0)),
+            SimEvent("2", EventTimestamp(0.0, 100.0, 0.0)),
+        ]
+        self.precedence = [(1, [(0, 0)]), (2, [(1, 1)])]
+
+        act0 = AnalyticEdge(DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5])))
+        act1 = AnalyticEdge(DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5])))
+        self.a_context = AnalyticContext(
+            events=self.events,
+            activities={(0, 1): (0, act0), (1, 2): (1, act1)},
+            precedence_list=self.precedence,
+            max_delay=5.0,
+        )
+
+        self.mc_context = SimContext(
+            events=self.events,
+            activities={(0, 1): (0, SimActivity(0.0, 1)), (1, 2): (1, SimActivity(0.0, 2))},
+            precedence_list=self.precedence,
+            max_delay=5.0,
+        )
+        gen = GenericDelayGenerator()
+        gen.add_empirical_absolute(1, [1.0, 2.0], [0.5, 0.5])
+        gen.add_empirical_absolute(2, [0.0, 1.0], [0.5, 0.5])
+        self.mc_sim = Simulator(self.mc_context, gen)
+
+    def test_compare_to_monte_carlo(self) -> None:
+        ds = DiscreteSimulator(self.a_context)
+        pmfs = ds.run()
+        final = pmfs[2]
+        samples = [self.mc_sim.run(seed=i).realized[2] for i in range(2000)]
+        counts = np.bincount(np.array(samples, dtype=int))[1:4]
+        mc_probs = counts / counts.sum()
+        self.assertTrue(np.allclose(final.values, [1.0, 2.0, 3.0]))
+        self.assertTrue(np.allclose(final.probs, [0.25, 0.5, 0.25], atol=0.05))
+        self.assertTrue(np.allclose(mc_probs, final.probs, atol=0.05))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `DiscretePMF` class with convolution and max/min operations
- add analytic context and `DiscreteSimulator`
- document discrete simulator usage
- test discrete propagation against Monte Carlo

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685870359d9c832294f263a06f3ea983