### PR TITLE
Fix typing imports and tuple usage

### DIFF
--- a/benchmarks/benchmark_simulator.py
+++ b/benchmarks/benchmark_simulator.py
@@ -5,17 +5,9 @@ from __future__ import annotations
 
 import random
 import time
-from typing import Iterable
+from collections.abc import Iterable
 
-from mc_dagprop import (
-    EventTimestamp,
-    GenericDelayGenerator,
-    SimActivity,
-    SimContext,
-    SimEvent,
-    Simulator,
-)
-
+from mc_dagprop import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, Simulator
 
 # Use a reasonably large graph similar to the one used in the tests
 N_NODES = 10_000
@@ -68,17 +60,13 @@ def main() -> None:
     c_single = benchmark_run(constant_sim, seeds * batches)
     print(f"Constant delay: {len(seeds) * batches} sequential runs took {c_single:.3f} s")
     c_batch = benchmark_run_many(constant_sim, batches, seeds)
-    print(
-        f"Constant delay: {batches} batched runs of {len(seeds)} seeds took {c_batch:.3f} s"
-    )
+    print(f"Constant delay: {batches} batched runs of {len(seeds)} seeds took {c_batch:.3f} s")
 
     exp_sim = build_exponential_sim(ctx)
     e_single = benchmark_run(exp_sim, seeds * batches)
     print(f"Exponential delay: {len(seeds) * batches} sequential runs took {e_single:.3f} s")
     e_batch = benchmark_run_many(exp_sim, batches, seeds)
-    print(
-        f"Exponential delay: {batches} batched runs of {len(seeds)} seeds took {e_batch:.3f} s"
-    )
+    print(f"Exponential delay: {batches} batched runs of {len(seeds)} seeds took {e_batch:.3f} s")
 
 
 if __name__ == "__main__":

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from mc_dagprop import SimEvent
 
@@ -9,7 +9,7 @@ from .pmf import DiscretePMF
 
 NodeIndex = int
 EdgeIndex = int
-Pred = Tuple[NodeIndex, EdgeIndex]
+Pred = tuple[NodeIndex, EdgeIndex]
 
 
 @dataclass
@@ -20,6 +20,6 @@ class AnalyticEdge:
 @dataclass
 class AnalyticContext:
     events: List[SimEvent]
-    activities: Dict[Tuple[NodeIndex, NodeIndex], Tuple[EdgeIndex, AnalyticEdge]]
-    precedence_list: List[Tuple[NodeIndex, List[Pred]]]
+    activities: Dict[tuple[NodeIndex, NodeIndex], tuple[EdgeIndex, AnalyticEdge]]
+    precedence_list: List[tuple[NodeIndex, List[Pred]]]
     max_delay: float = 0.0

--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 import numpy as np
 


### PR DESCRIPTION
## Summary
- use builtin `tuple` typing in discrete context
- import `Iterable` from `collections.abc` in pmf and benchmark
- format with `isort` and `black`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591fc2f2dc8322a42bbe9ecf5f0584