### PR TITLE
Add step size validation for discrete simulator

### DIFF
--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
+import numpy as np
+
 from mc_dagprop import SimEvent
 
 from .pmf import DiscretePMF
@@ -23,3 +25,11 @@ class AnalyticContext:
     activities: Dict[Tuple[NodeIndex, NodeIndex], Tuple[EdgeIndex, AnalyticEdge]]
     precedence_list: List[Tuple[NodeIndex, List[Pred]]]
     max_delay: float = 0.0
+    step_size: float = 0.0
+
+    def validate(self) -> None:
+        for _, edge in self.activities.values():
+            if not np.isclose(edge.pmf.step, self.step_size):
+                raise ValueError(
+                    f"edge PMF step {edge.pmf.step} does not match context step size {self.step_size}"
+                )

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -12,6 +12,7 @@ class DiscreteSimulator:
 
     def __init__(self, context: AnalyticContext):
         self.context = context
+        self.context.validate()
         self._build_topology()
 
     def _build_topology(self) -> None:

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -31,6 +31,7 @@ class TestDiscreteSimulator(unittest.TestCase):
             activities={(0, 1): (0, act0), (1, 2): (1, act1)},
             precedence_list=self.precedence,
             max_delay=5.0,
+            step_size=1.0,
         )
 
         self.mc_context = SimContext(
@@ -54,6 +55,19 @@ class TestDiscreteSimulator(unittest.TestCase):
         self.assertTrue(np.allclose(final.values, [1.0, 2.0, 3.0]))
         self.assertTrue(np.allclose(final.probs, [0.25, 0.5, 0.25], atol=0.05))
         self.assertTrue(np.allclose(mc_probs, final.probs, atol=0.05))
+
+    def test_mismatched_step_size(self) -> None:
+        act0 = AnalyticEdge(DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5])))
+        act1 = AnalyticEdge(DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5])))
+        ctx = AnalyticContext(
+            events=self.events,
+            activities={(0, 1): (0, act0), (1, 2): (1, act1)},
+            precedence_list=self.precedence,
+            max_delay=5.0,
+            step_size=2.0,
+        )
+        with self.assertRaises(ValueError):
+            DiscreteSimulator(ctx)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support step_size on AnalyticContext and provide a validation method
- call `context.validate()` when initializing `DiscreteSimulator`
- adjust discrete simulator tests and add check for mismatched step sizes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591fbf59f88322a1c8a2d83b4fa3ec