### PR TITLE
Add PMF bounds to analytic simulator

### DIFF
--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version
 
 from ._core import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, SimResult, Simulator
-from .discrete import AnalyticContext, DiscretePMF, DiscreteSimulator
+from .discrete import AnalyticContext, AnalyticEvent, DiscretePMF, DiscreteSimulator
 from .utils.inspection import plot_activity_delays, retrieve_absolute_and_relative_delays
 
 __version__ = version("mc-dagprop")
@@ -15,6 +15,7 @@ __all__ = [
     "Simulator",
     "EventTimestamp",
     "DiscretePMF",
+    "AnalyticEvent",
     "AnalyticContext",
     "DiscreteSimulator",
     "plot_activity_delays",

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -1,5 +1,5 @@
 from .pmf import DiscretePMF
-from .context import AnalyticContext
+from .context import AnalyticContext, AnalyticEvent
 from .simulator import DiscreteSimulator
 
-__all__ = ["DiscretePMF", "AnalyticContext", "DiscreteSimulator"]
+__all__ = ["DiscretePMF", "AnalyticEvent", "AnalyticContext", "DiscreteSimulator"]

--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -91,3 +91,15 @@ class DiscretePMF:
         overflow = self.probs[idx + 1 :].sum()
         new_probs[-1] += overflow
         return DiscretePMF(new_vals, new_probs)
+
+    def truncate(self, min_value: float, max_value: float) -> tuple["DiscretePMF", float, float]:
+        """Truncate the PMF to ``[min_value, max_value]`` and return under/overflow mass."""
+        under = float(self.probs[self.values < min_value].sum())
+        over = float(self.probs[self.values > max_value].sum())
+        mask = (self.values >= min_value) & (self.values <= max_value)
+        new_vals = self.values[mask]
+        new_probs = self.probs[mask]
+        if new_vals.size == 0:
+            new_vals = np.array([min_value], dtype=float)
+            new_probs = np.array([0.0], dtype=float)
+        return DiscretePMF(new_vals, new_probs), under, over


### PR DESCRIPTION
## Summary
- support per-event bounds via new `AnalyticEvent`
- adjust `AnalyticContext` and `DiscreteSimulator` to use event bounds
- export `AnalyticEvent` in package API
- update tests for per-event bounds

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685922bd14688322bd1bd6a937156e0c