### PR TITLE
Handle edge case in truncate_right

### DIFF
--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -85,6 +85,11 @@ class DiscretePMF:
     def truncate_right(self, max_value: float) -> "DiscretePMF":
         if max_value >= self.values[-1]:
             return self
+        if max_value <= self.values[0]:
+            return DiscretePMF(
+                np.array([max_value], dtype=float),
+                np.array([1.0], dtype=float),
+            )
         idx = np.searchsorted(self.values, max_value, side="right") - 1
         new_vals = self.values[: idx + 1]
         new_probs = self.probs[: idx + 1]

--- a/test/test_pmf.py
+++ b/test/test_pmf.py
@@ -1,0 +1,16 @@
+import unittest
+import numpy as np
+
+from mc_dagprop.discrete.pmf import DiscretePMF
+
+
+class TestDiscretePMF(unittest.TestCase):
+    def test_truncate_right_below_first_value(self) -> None:
+        pmf = DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5]))
+        truncated = pmf.truncate_right(0.5)
+        self.assertTrue(np.allclose(truncated.values, [0.5]))
+        self.assertTrue(np.allclose(truncated.probs, [1.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix DiscretePMF.truncate_right when `max_value` is before the first value
- add regression test for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859291d25048322b8c7e66ac8ae1795