### PR TITLE
Switch to tuples for AnalyticContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,14 @@ Define per-edge probability mass functions and build an `AnalyticContext`:
 ```python
 from mc_dagprop import AnalyticContext, DiscretePMF, DiscreteSimulator, EventTimestamp, SimEvent
 
-events = [SimEvent("A", EventTimestamp(0, 10, 0)), SimEvent("B", EventTimestamp(0, 10, 0))]
+events = (
+    SimEvent("A", EventTimestamp(0, 10, 0)),
+    SimEvent("B", EventTimestamp(0, 10, 0)),
+)
 activities = {(0, 1): (0, DiscretePMF([1.0, 2.0], [0.5, 0.5]))}
-precedence = [(1, [(0, 0)])]
+precedence = (
+    (1, ((0, 0),)),
+)
 ctx = AnalyticContext(
     events=events,
     activities=activities,

--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
+
 # Some comments on the code, things to improve or change:
 # TODO: Define a custum type, Second, that is a float, but has a unit of seconds, which we can use in the future.
 # TODO: Define a custom type, Probability, that is a float, but has a unit of probability, which we can use in the future.
 
 # Please use from __future__ import annotations to ensure that the type hints are better readable
 
-@dataclass(frozen=True, slots=True,)
+
+@dataclass(frozen=True, slots=True)
 class DiscretePMF:
     """Simple probability mass function on an equidistant grid."""
 
@@ -22,13 +24,13 @@ class DiscretePMF:
         if not np.isclose(self.probs.sum(), 1.0):
             # FIXME: This is not something we should be doing here, as this is causing behavioral changes.
             # We can raise an error instead
-            self.probs = self.probs / self.probs.sum()
+            object.__setattr__(self, "probs", self.probs / self.probs.sum())
 
         # FIXME Wouldn't it be better to just expect sorted values? I would instead have a validate method,
         #  that checks if the values are sorted. and if the probs are normalized.
         order = np.argsort(self.values)
-        self.values = self.values[order]
-        self.probs = self.probs[order]
+        object.__setattr__(self, "values", self.values[order])
+        object.__setattr__(self, "probs", self.probs[order])
         # merge identical values
 
         # TODO: SAme as above, this is not something we should be doing here.
@@ -36,8 +38,8 @@ class DiscretePMF:
         if len(uniq) != len(self.values):
             agg = np.zeros_like(uniq, dtype=float)
             np.add.at(agg, indices, self.probs)
-            self.values = uniq
-            self.probs = agg
+            object.__setattr__(self, "values", uniq)
+            object.__setattr__(self, "probs", agg)
 
     # Step should be a static property, defined on init. Again, someting that we can validate in a separate method.
     @property


### PR DESCRIPTION
## Summary
- store `AnalyticContext.events` and `precedence_list` as tuples
- ensure `DiscretePMF` can mutate fields during `__post_init__`
- update discrete simulator tests for tuple usage
- document tuple usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859491245088322b06be6f006855237