### PR TITLE
Introduce ScheduledEvent and SimulatedEvent dataclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ This computes event-time PMFs deterministically without Monte-Carlo sampling.
 The ``step_size`` sets the spacing for all values in the discrete PMFs.
 ``DiscreteSimulator`` invokes ``AnalyticContext.validate()`` at construction
 time and will raise an error when any edge uses a different step.
-Each ``AnalyticEvent`` may specify ``bounds=(lower, upper)`` to clip the
+Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
 resulting distribution. Mass cut off below or above those limits is recorded in
 the simulator's ``underflow`` and ``overflow`` lists after ``run()``.
 By default the step size is ``1.0`` second and typical delay deviations range

--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -1,7 +1,13 @@
 from importlib.metadata import version
 
 from ._core import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, SimResult, Simulator
-from .discrete import AnalyticContext, AnalyticEvent, DiscretePMF, DiscreteSimulator
+from .discrete import (
+    AnalyticContext,
+    DiscretePMF,
+    DiscreteSimulator,
+    ScheduledEvent,
+    SimulatedEvent,
+)
 from .utils.inspection import plot_activity_delays, retrieve_absolute_and_relative_delays
 
 __version__ = version("mc-dagprop")
@@ -15,7 +21,8 @@ __all__ = [
     "Simulator",
     "EventTimestamp",
     "DiscretePMF",
-    "AnalyticEvent",
+    "ScheduledEvent",
+    "SimulatedEvent",
     "AnalyticContext",
     "DiscreteSimulator",
     "plot_activity_delays",

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -1,5 +1,11 @@
-from .context import AnalyticContext, AnalyticEvent
+from .context import AnalyticContext, ScheduledEvent, SimulatedEvent
 from .pmf import DiscretePMF
 from .simulator import DiscreteSimulator
 
-__all__ = ["DiscretePMF", "AnalyticEvent", "AnalyticContext", "DiscreteSimulator"]
+__all__ = [
+    "DiscretePMF",
+    "ScheduledEvent",
+    "SimulatedEvent",
+    "AnalyticContext",
+    "DiscreteSimulator",
+]

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -25,10 +25,16 @@ class AnalyticEdge:
 
 
 @dataclass
-class AnalyticEvent:
-    id: str
+class ScheduledEvent:
     timestamp: EventTimestamp
     bounds: tuple[float, float] | None = None
+
+
+@dataclass
+class SimulatedEvent:
+    pmf: DiscretePMF
+    underflow: float
+    overflow: float
 
 
 # TODO: we should have a scheduled event and a simulated event, where the scheduled event has a timestamp and bounds,
@@ -37,7 +43,7 @@ class AnalyticEvent:
 
 @dataclass
 class AnalyticContext:
-    events: tuple[AnalyticEvent, ...]
+    events: tuple[ScheduledEvent, ...]
     activities: dict[tuple[NodeIndex, NodeIndex], tuple[EdgeIndex, AnalyticEdge]]
     precedence_list: tuple[tuple[NodeIndex, tuple[Pred, ...]], ...]
     max_delay: float = 0.0


### PR DESCRIPTION
## Summary
- add `ScheduledEvent` and `SimulatedEvent` dataclasses
- adjust `AnalyticContext` and simulator to use new events
- export the new classes from the package
- update documentation and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594b63aa8883228188a8c9e0958b02