### PR TITLE
Add ScheduledEvent and SimulatedEvent dataclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ This computes event-time PMFs deterministically without Monte-Carlo sampling.
 The ``step_size`` sets the spacing for all values in the discrete PMFs.
 ``DiscreteSimulator`` invokes ``AnalyticContext.validate()`` at construction
 time and will raise an error when any edge uses a different step.
-Each ``AnalyticEvent`` may specify ``bounds=(lower, upper)`` to clip the
+Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
 resulting distribution. Mass cut off below or above those limits is recorded in
 the simulator's ``underflow`` and ``overflow`` lists after ``run()``.
 By default the step size is ``1.0`` second and typical delay deviations range

--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -1,7 +1,13 @@
 from importlib.metadata import version
 
 from ._core import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, SimResult, Simulator
-from .discrete import AnalyticContext, AnalyticEvent, DiscretePMF, DiscreteSimulator
+from .discrete import (
+    AnalyticContext,
+    ScheduledEvent,
+    SimulatedEvent,
+    DiscretePMF,
+    DiscreteSimulator,
+)
 from .utils.inspection import plot_activity_delays, retrieve_absolute_and_relative_delays
 
 __version__ = version("mc-dagprop")
@@ -15,7 +21,8 @@ __all__ = [
     "Simulator",
     "EventTimestamp",
     "DiscretePMF",
-    "AnalyticEvent",
+    "ScheduledEvent",
+    "SimulatedEvent",
     "AnalyticContext",
     "DiscreteSimulator",
     "plot_activity_delays",

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -1,5 +1,11 @@
-from .context import AnalyticContext, AnalyticEvent
+from .context import AnalyticContext, ScheduledEvent, SimulatedEvent
 from .pmf import DiscretePMF
 from .simulator import DiscreteSimulator
 
-__all__ = ["DiscretePMF", "AnalyticEvent", "AnalyticContext", "DiscreteSimulator"]
+__all__ = [
+    "DiscretePMF",
+    "ScheduledEvent",
+    "SimulatedEvent",
+    "AnalyticContext",
+    "DiscreteSimulator",
+]

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -25,14 +25,17 @@ class AnalyticEdge:
 
 
 @dataclass(frozen=True, slots=True)
-class AnalyticEvent:
+class ScheduledEvent:
     id: str
     timestamp: EventTimestamp
     bounds: tuple[float, float] | None = None
 
-    def __post_init__(self) -> None:
-        if self.bounds is None:
-            object.__setattr__(self, "bounds", (self.timestamp.earliest, self.timestamp.latest))
+
+@dataclass(frozen=True, slots=True)
+class SimulatedEvent:
+    pmf: DiscretePMF
+    underflow: float
+    overflow: float
 
 
 # TODO: we should have a scheduled event and a simulated event, where the scheduled event has a timestamp and bounds,
@@ -41,7 +44,7 @@ class AnalyticEvent:
 
 @dataclass(frozen=True, slots=True)
 class AnalyticContext:
-    events: tuple[AnalyticEvent, ...]
+    events: tuple[ScheduledEvent, ...]
     activities: dict[tuple[NodeIndex, NodeIndex], tuple[EdgeIndex, AnalyticEdge]]
     precedence_list: tuple[tuple[NodeIndex, tuple[Pred, ...]], ...]
     max_delay: float = 0.0

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -67,7 +67,11 @@ class DiscreteSimulator:
                     candidate = event_pmfs[src].convolve(edge_pmf)
                     cur = candidate if cur is None else cur.maximum(candidate)
                 pmf = cur if cur is not None else base
-            lb, ub = ev.bounds
+            lb, ub = (
+                ev.bounds
+                if ev.bounds is not None
+                else (ev.timestamp.earliest, ev.timestamp.latest)
+            )
             pmf, u, o = pmf.truncate(lb, ub)
             under[idx] = u
             over[idx] = o

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from mc_dagprop import (
     AnalyticContext,
-    AnalyticEvent,
+    ScheduledEvent,
     DiscretePMF,
     DiscreteSimulator,
     EventTimestamp,
@@ -19,9 +19,9 @@ from mc_dagprop.discrete.context import AnalyticEdge
 class TestDiscreteSimulator(unittest.TestCase):
     def setUp(self) -> None:
         self.events = (
-            AnalyticEvent("0", EventTimestamp(0.0, 100.0, 0.0)),
-            AnalyticEvent("1", EventTimestamp(0.0, 100.0, 0.0)),
-            AnalyticEvent("2", EventTimestamp(0.0, 100.0, 0.0)),
+            ScheduledEvent("0", EventTimestamp(0.0, 100.0, 0.0)),
+            ScheduledEvent("1", EventTimestamp(0.0, 100.0, 0.0)),
+            ScheduledEvent("2", EventTimestamp(0.0, 100.0, 0.0)),
         )
         self.mc_events = (
             SimEvent("0", EventTimestamp(0.0, 100.0, 0.0)),
@@ -77,9 +77,9 @@ class TestDiscreteSimulator(unittest.TestCase):
 
     def test_bounds_and_overflow(self) -> None:
         events = (
-            AnalyticEvent("0", EventTimestamp(0.0, 100.0, 0.0), bounds=(0.0, 0.0)),
-            AnalyticEvent("1", EventTimestamp(0.0, 100.0, 0.0), bounds=(0.0, 1.5)),
-            AnalyticEvent("2", EventTimestamp(0.0, 100.0, 0.0), bounds=(0.0, 1.8)),
+            ScheduledEvent("0", EventTimestamp(0.0, 100.0, 0.0), bounds=(0.0, 0.0)),
+            ScheduledEvent("1", EventTimestamp(0.0, 100.0, 0.0), bounds=(0.0, 1.5)),
+            ScheduledEvent("2", EventTimestamp(0.0, 100.0, 0.0), bounds=(0.0, 1.8)),
         )
         ctx = AnalyticContext(
             events=events,
@@ -103,7 +103,7 @@ class TestDiscreteSimulator(unittest.TestCase):
     def test_large_uniform_network(self) -> None:
         values = np.arange(-180.0, 1800.1, 1.0)
         probs = np.ones_like(values, dtype=float) / len(values)
-        events = tuple(AnalyticEvent(str(i), EventTimestamp(0.0, 2000.0, 0.0)) for i in range(5))
+        events = tuple(ScheduledEvent(str(i), EventTimestamp(0.0, 2000.0, 0.0)) for i in range(5))
         precedence = ((1, ((0, 0),)), (2, ((0, 1),)), (3, ((1, 2), (2, 3))), (4, ((2, 4), (3, 5))))
         activities = {
             (0, 1): (0, AnalyticEdge(DiscretePMF(values, probs))),


### PR DESCRIPTION
## Summary
- create `ScheduledEvent` and `SimulatedEvent` dataclasses
- switch `AnalyticContext` and simulator to use `ScheduledEvent`
- export new dataclasses from the package
- update README and tests for new API

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685952a90e688322a407d25e28b019de