### PR TITLE
Introduce typed Second and Probability

### DIFF
--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from mc_dagprop import EventTimestamp
-from .pmf import DiscretePMF
+from .pmf import DiscretePMF, Probability, Second
 
 # TODO:
 #  General comments: Please avoid using list as return type annotations, as they are mutable and can lead to unexpected
@@ -28,14 +28,14 @@ class AnalyticEdge:
 class ScheduledEvent:
     id: str
     timestamp: EventTimestamp
-    bounds: tuple[float, float] | None = None
+    bounds: tuple[Second, Second] | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class SimulatedEvent:
     pmf: DiscretePMF
-    underflow: float
-    overflow: float
+    underflow: Probability
+    overflow: Probability
 
 
 # TODO: we should have a scheduled event and a simulated event, where the scheduled event has a timestamp and bounds,
@@ -47,8 +47,8 @@ class AnalyticContext:
     events: tuple[ScheduledEvent, ...]
     activities: dict[tuple[NodeIndex, NodeIndex], tuple[EdgeIndex, AnalyticEdge]]
     precedence_list: tuple[tuple[NodeIndex, tuple[Pred, ...]], ...]
-    max_delay: float = 0.0
-    step_size: float = 0.0
+    max_delay: Second = 0.0
+    step_size: Second = 0.0
 
     def __post_init__(self) -> None:
         # Accept sequences in the constructor but store tuples internally to

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -4,7 +4,7 @@ from collections import deque
 from dataclasses import dataclass, field
 
 from .context import AnalyticContext, Pred
-from .pmf import DiscretePMF
+from .pmf import DiscretePMF, Probability
 
 @dataclass(frozen=True, slots=True)
 class DiscreteSimulator:
@@ -13,8 +13,8 @@ class DiscreteSimulator:
     context: AnalyticContext
     _preds_by_target: list[tuple[Pred, ...] | None] = field(init=False, repr=False)
     order: list[int] = field(init=False, repr=False)
-    underflow: list[float] = field(init=False, repr=False)
-    overflow: list[float] = field(init=False, repr=False)
+    underflow: list[Probability] = field(init=False, repr=False)
+    overflow: list[Probability] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.context.validate()
@@ -52,8 +52,8 @@ class DiscreteSimulator:
 
         n_events = len(self.context.events)
         event_pmfs: list[DiscretePMF] = [None] * n_events  # type: ignore
-        under: list[float] = [0.0] * n_events
-        over: list[float] = [0.0] * n_events
+        under: list[Probability] = [0.0] * n_events
+        over: list[Probability] = [0.0] * n_events
         for idx in self.order:
             ev = self.context.events[idx]
             base = DiscretePMF.delta(ev.timestamp.earliest)


### PR DESCRIPTION
## Summary
- add `Second` and `Probability` via `typing.NewType`
- update discrete modules to use these typed aliases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595491b8608322a53617e4d82c3d66