### PR TITLE
Implement PMF validation & restructure simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ The ``step_size`` sets the spacing for all values in the discrete PMFs.
 ``DiscreteSimulator`` invokes ``AnalyticContext.validate()`` at construction
 time and will raise an error when any edge uses a different step.
 Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
-resulting distribution. Mass cut off below or above those limits is recorded in
-the simulator's ``underflow`` and ``overflow`` lists after ``run()``.
+resulting distribution. The ``run()`` method returns a sequence of
+``SimulatedEvent`` objects which hold the resulting PMF and the under- and
+overflow mass for that event.
 By default the step size is ``1.0`` second and typical delay deviations range
 roughly from ``-180`` s up to ``+1800`` s.
 

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -28,7 +28,12 @@ class AnalyticEdge:
 class ScheduledEvent:
     id: str
     timestamp: EventTimestamp
+
     bounds: tuple[Second, Second] | None = None
+
+    def __post_init__(self) -> None:
+        if self.bounds is None:
+            object.__setattr__(self, "bounds", (self.timestamp.earliest, self.timestamp.latest))
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- validate PMFs instead of mutating them on creation
- keep step size as an attribute
- return under/overflow with each simulated event
- set bounds on `ScheduledEvent` automatically
- adjust tests and docs

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685956ebe4ec8322a298cd971f5fac84