### PR TITLE
Simplify __init__ imports

### DIFF
--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -1,3 +1,5 @@
+"""Public interface for the :mod:`mc_dagprop` package."""
+
 from importlib.metadata import version
 
 try:
@@ -10,41 +12,11 @@ try:
         SimResult,
         Simulator,
     )
-except ModuleNotFoundError:  # pragma: no cover - optional native module
-    try:  # fallback to extension from an installed package
-        import importlib.util
-        import glob
-        import os
-        import sys
-
-        core_path = None
-        for _p in sys.path[1:]:
-            cand = os.path.join(_p, "mc_dagprop")
-            if os.path.isdir(cand):
-                matches = glob.glob(os.path.join(cand, "_core.*"))
-                if matches:
-                    # Prefer the compiled extension if available.
-                    matches.sort(key=lambda p: 0 if p.endswith(".so") else 1)
-                    core_path = matches[0]
-                    break
-        if core_path is None:
-            raise FileNotFoundError
-
-        spec = importlib.util.spec_from_file_location("mc_dagprop._core", core_path)
-        if spec is None or spec.loader is None:
-            raise ImportError
-        _c = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(_c)
-
-        EventTimestamp = _c.EventTimestamp
-        GenericDelayGenerator = _c.GenericDelayGenerator
-        SimActivity = _c.SimActivity
-        SimContext = _c.SimContext
-        SimEvent = _c.SimEvent
-        SimResult = _c.SimResult
-        Simulator = _c.Simulator
-    except Exception:  # pragma: no cover - give up
-        EventTimestamp = GenericDelayGenerator = SimActivity = SimContext = SimEvent = Simulator = SimResult = None  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - compiled module missing
+    raise ImportError(
+        "mc_dagprop requires the compiled extension 'mc_dagprop._core'. "
+        "Install the package from source to build it."
+    ) from exc
 from .discrete import (
     AnalyticContext,
     ScheduledEvent,


### PR DESCRIPTION
## Summary
- remove dynamic import fallback logic from package initializer
- require compiled extension and show clear error message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685961a0ca308322bf2227134a9772d3