### PR TITLE
Add documentation for discrete context classes

### DIFF
--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -21,11 +21,25 @@ Pred = tuple[NodeIndex, EdgeIndex]
 
 @dataclass(frozen=True, slots=True)
 class AnalyticEdge:
+    """Edge with an associated delay distribution.
+
+    Attributes:
+        pmf: Probability mass function describing the delay on this edge.
+    """
+
     pmf: DiscretePMF
 
 
 @dataclass(frozen=True, slots=True)
 class ScheduledEvent:
+    """Timing information for a planned event.
+
+    Attributes:
+        id: Unique identifier of the event.
+        timestamp: Earliest, latest and nominal time bounds.
+        bounds: Optional lower and upper bounds used for simulation.
+    """
+
     id: str
     timestamp: EventTimestamp
 
@@ -38,6 +52,14 @@ class ScheduledEvent:
 
 @dataclass(frozen=True, slots=True)
 class SimulatedEvent:
+    """Result of propagating a scheduled event.
+
+    Attributes:
+        pmf: Distribution of simulated event times.
+        underflow: Probability mass below the lower bound.
+        overflow: Probability mass above the upper bound.
+    """
+
     pmf: DiscretePMF
     underflow: Probability
     overflow: Probability
@@ -49,6 +71,16 @@ class SimulatedEvent:
 
 @dataclass(frozen=True, slots=True)
 class AnalyticContext:
+    """Container describing the analytic propagation network.
+
+    Attributes:
+        events: Immutable sequence of scheduled events.
+        activities: Mapping from (source, target) node pairs to analytic edges.
+        precedence_list: List of ``(target, predecessors)`` tuples.
+        max_delay: Global cap on allowed propagation delay.
+        step_size: Discrete time step shared by all distributions.
+    """
+
     events: tuple[ScheduledEvent, ...]
     activities: dict[tuple[NodeIndex, NodeIndex], tuple[EdgeIndex, AnalyticEdge]]
     precedence_list: tuple[tuple[NodeIndex, tuple[Pred, ...]], ...]


### PR DESCRIPTION
## Summary
- document the discrete-context dataclasses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596b8446448322ae0f2ef1e5dca5d3