### PR TITLE
Fix typo in comment

### DIFF
--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -45,7 +45,7 @@ class DiscretePMF:
         if not np.isclose(self.probs.sum(), 1.0):
             raise ValueError("probabilities must sum to 1.0")
 
-    # Step should be a static property, defined on init. Again, someting that we can validate in a separate method.
+    # Step should be a static property, defined on init. Again, something that we can validate in a separate method.
     @property
     def step(self) -> Second:
         return self.step_size


### PR DESCRIPTION
## Summary
- correct a minor typo in `DiscretePMF`
- build extension and run tests

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68596bbb33788322ad1fc6d720d09d21