### PR TITLE
Document deterministic nodes and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ time and will raise an error when any edge uses a different step.
 Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
 resulting distribution. The ``run()`` method returns a sequence of
 ``SimulatedEvent`` objects which hold the resulting PMF and the under- and
-overflow mass for that event.
+overflow mass for that event. Events without predecessors are deterministic and
+their PMFs collapse to a single value at the earliest bound.
 By default the step size is ``1.0`` second and typical delay deviations range
 roughly from ``-180`` s up to ``+1800`` s.
 

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -61,7 +61,8 @@ class DiscreteSimulator:
 
         Each node's distribution is derived from its predecessors and the
         result is returned as a tuple of :class:`SimulatedEvent` objects in
-        original order.
+        original order. Nodes without incoming edges are deterministic and
+        their PMF collapses to a delta at the event's earliest timestamp.
         """
         n_events = len(self.context.events)
         # NOTE[codex]: We need index-based lookup for predecessors. Using a

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -67,6 +67,16 @@ class TestDiscreteSimulator(unittest.TestCase):
         self.assertTrue(np.allclose(final.probs, [0.25, 0.5, 0.25], atol=0.05))
         self.assertTrue(np.allclose(mc_probs, final.probs, atol=0.05))
 
+    def test_event_without_predecessor(self) -> None:
+        ds = create_discrete_simulator(self.a_context)
+        events = ds.run()
+        first = events[0].pmf
+        earliest = self.events[0].timestamp.earliest
+        self.assertTrue(np.allclose(first.values, [earliest]))
+        self.assertTrue(np.allclose(first.probs, [1.0]))
+        mc_res = self.mc_sim.run(seed=0)
+        self.assertEqual(mc_res.cause_event[0], -1)
+
     def test_mismatched_step_size(self) -> None:
         act0 = AnalyticEdge(DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5])))
         act1 = AnalyticEdge(DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5])))


### PR DESCRIPTION
## Summary
- clarify docstring for DiscreteSimulator.run
- explain deterministic source nodes in README
- add unit test for source events with no predecessors

## Testing
- `python -m unittest discover -s test -p '*.py' -v`

------
https://chatgpt.com/codex/tasks/task_e_685971d52e2c8322afc9f5be96ad0cd6