### PR TITLE
Add bound handling rules to discrete simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,12 @@ The ``step_size`` sets the spacing for all values in the discrete PMFs.
 ``DiscreteSimulator`` invokes ``AnalyticContext.validate()`` at construction
 time and will raise an error when any edge uses a different step.
 Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
-resulting distribution. The ``run()`` method returns a sequence of
-``SimulatedEvent`` objects which hold the resulting PMF and the under- and
-overflow mass for that event. Events without predecessors are deterministic and
+resulting distribution. Overflow and underflow mass can either be truncated to
+the closest bound or removed entirely. Control this behaviour via the optional
+``underflow_rule`` and ``overflow_rule`` arguments of
+``create_discrete_simulator()``. The ``run()`` method returns a sequence of
+``SimulatedEvent`` objects which hold the resulting PMF and the probability mass
+discarded on either side. Events without predecessors are deterministic and
 their PMFs collapse to a single value at the earliest bound.
 By default the step size is ``1.0`` second and typical delay deviations range
 roughly from ``-180`` s up to ``+1800`` s.

--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -22,6 +22,8 @@ from .discrete import (
     ScheduledEvent,
     SimulatedEvent,
     DiscretePMF,
+    UnderflowRule,
+    OverflowRule,
     DiscreteSimulator,
     create_discrete_simulator,
 )
@@ -40,6 +42,8 @@ __all__ = [
     "DiscretePMF",
     "ScheduledEvent",
     "SimulatedEvent",
+    "UnderflowRule",
+    "OverflowRule",
     "AnalyticContext",
     "DiscreteSimulator",
     "create_discrete_simulator",

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -1,11 +1,13 @@
 from .context import AnalyticContext, ScheduledEvent, SimulatedEvent
-from .pmf import DiscretePMF
+from .pmf import DiscretePMF, UnderflowRule, OverflowRule
 from .simulator import DiscreteSimulator, create_discrete_simulator
 
 __all__ = [
     "DiscretePMF",
     "ScheduledEvent",
     "SimulatedEvent",
+    "UnderflowRule",
+    "OverflowRule",
     "AnalyticContext",
     "DiscreteSimulator",
     "create_discrete_simulator",

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from typing import cast
 
 from .context import AnalyticContext, Pred, SimulatedEvent
-from .pmf import DiscretePMF, Probability
+from .pmf import (
+    DiscretePMF,
+    Probability,
+    UnderflowRule,
+    OverflowRule,
+    apply_bounds,
+)
 
 
 def build_topology(
@@ -41,28 +47,47 @@ def build_topology(
     return preds_by_target, order
 
 
-def create_discrete_simulator(context: AnalyticContext) -> "DiscreteSimulator":
+def create_discrete_simulator(
+    context: AnalyticContext,
+    *,
+    underflow_rule: UnderflowRule = UnderflowRule.TRUNCATE,
+    overflow_rule: OverflowRule = OverflowRule.TRUNCATE,
+) -> "DiscreteSimulator":
     """Return a :class:`DiscreteSimulator` with topology built for ``context``."""
 
     context.validate()
     preds, order = build_topology(context)
-    return DiscreteSimulator(context=context, _preds_by_target=preds, order=order)
+    return DiscreteSimulator(
+        context=context,
+        _preds_by_target=preds,
+        order=order,
+        underflow_rule=underflow_rule,
+        overflow_rule=overflow_rule,
+    )
 
 @dataclass(frozen=True, slots=True)
 class DiscreteSimulator:
-    """Propagate discrete PMFs through a DAG."""
+    """Propagate discrete PMFs through a DAG.
+
+    Probability mass outside an event's bounds can either be truncated to the
+    nearest bound or removed entirely. The behaviour is controlled via the
+    ``underflow_rule`` and ``overflow_rule`` attributes.
+    """
 
     context: AnalyticContext
     _preds_by_target: list[tuple[Pred, ...] | None]
     order: list[int]
+    underflow_rule: UnderflowRule = UnderflowRule.TRUNCATE
+    overflow_rule: OverflowRule = OverflowRule.TRUNCATE
 
     def run(self) -> tuple[SimulatedEvent, ...]:
         """Propagate events through the DAG to compute node PMFs.
 
-        Each node's distribution is derived from its predecessors and the
-        result is returned as a tuple of :class:`SimulatedEvent` objects in
-        original order. Nodes without incoming edges are deterministic and
-        their PMF collapses to a delta at the event's earliest timestamp.
+        Each node's distribution is derived from its predecessors and the result
+        is returned as a tuple of :class:`SimulatedEvent` objects in original
+        order. Nodes without incoming edges are deterministic and their PMF
+        collapses to a delta at the event's earliest timestamp. Probability mass
+        removed by ``apply_bounds`` is recorded per event.
         """
         n_events = len(self.context.events)
         # NOTE[codex]: We need index-based lookup for predecessors. Using a
@@ -83,7 +108,13 @@ class DiscreteSimulator:
                     cur = candidate if cur is None else cur.maximum(candidate)
                 pmf = cur if cur is not None else base
             lb, ub = ev.bounds
-            pmf, u, o = pmf.truncate(lb, ub)
+            pmf, u, o = apply_bounds(
+                pmf,
+                lb,
+                ub,
+                underflow_rule=self.underflow_rule,
+                overflow_rule=self.overflow_rule,
+            )
             events[idx] = SimulatedEvent(pmf, u, o)
 
         return tuple(events[i] for i in range(n_events))


### PR DESCRIPTION
## Summary
- introduce `UnderflowRule` and `OverflowRule`
- allow `create_discrete_simulator` and `DiscreteSimulator` to configure bound rules
- implement `apply_bounds` helper in `pmf.py`
- use `apply_bounds` in simulator
- extend tests for new behaviour
- document rules in README

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_685973fe4fc083228d622a609bec1f8b