### PR TITLE
Add grid alignment validation for DiscretePMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ This computes event-time PMFs deterministically without Monte-Carlo sampling.
 
 The ``step_size`` sets the spacing for all values in the discrete PMFs.
 ``DiscreteSimulator`` invokes ``AnalyticContext.validate()`` at construction
-time and will raise an error when any edge uses a different step.
+time and will raise an error when any edge uses a different step.  All PMF
+value grids must therefore have constant spacing equal to ``step_size`` and
+start on a multiple of that step.
 Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
 resulting distribution. The ``run()`` method returns a sequence of
 ``SimulatedEvent`` objects which hold the resulting PMF and the under- and

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -11,6 +11,7 @@ NodeIndex = int
 EdgeIndex = int
 Pred = tuple[NodeIndex, EdgeIndex]
 
+
 @dataclass(frozen=True, slots=True)
 class AnalyticEdge:
     """Edge with an associated delay distribution.
@@ -20,6 +21,7 @@ class AnalyticEdge:
     """
 
     pmf: DiscretePMF
+
 
 @dataclass(frozen=True, slots=True)
 class ScheduledEvent:
@@ -40,6 +42,7 @@ class ScheduledEvent:
         if self.bounds is None:
             object.__setattr__(self, "bounds", (self.timestamp.earliest, self.timestamp.latest))
 
+
 @dataclass(frozen=True, slots=True)
 class SimulatedEvent:
     """Result of propagating a scheduled event.
@@ -53,6 +56,7 @@ class SimulatedEvent:
     pmf: DiscretePMF
     underflow: Probability
     overflow: Probability
+
 
 @dataclass(frozen=True, slots=True)
 class AnalyticContext:
@@ -88,3 +92,4 @@ class AnalyticContext:
         for _, edge in self.activities.values():
             if not np.isclose(edge.pmf.step, self.step_size):
                 raise ValueError(f"edge PMF step {edge.pmf.step} does not match context step size {self.step_size}")
+            edge.pmf.validate_alignment(self.step_size)

--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -45,6 +45,20 @@ class DiscretePMF:
         if not np.isclose(self.probs.sum(), 1.0):
             raise ValueError("probabilities must sum to 1.0")
 
+    def validate_alignment(self, step: Second) -> None:
+        """Ensure that ``values`` align with ``step`` spacing."""
+
+        if step <= 0.0:
+            raise ValueError("step must be positive")
+
+        if len(self.values) > 1:
+            diffs = np.diff(self.values)
+            if not np.allclose(diffs, step):
+                raise ValueError("PMF grid spacing does not match step")
+
+        if self.values.size > 0 and not np.isclose(self.values[0] % step, 0.0):
+            raise ValueError("PMF values are not aligned to step grid")
+
     # Step should be a static property, defined on init. Again, something that we can validate in a separate method.
     @property
     def step(self) -> Second:

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -90,6 +90,18 @@ class TestDiscreteSimulator(unittest.TestCase):
         with self.assertRaises(ValueError):
             create_discrete_simulator(ctx)
 
+    def test_misaligned_values(self) -> None:
+        act0 = AnalyticEdge(DiscretePMF(np.array([1.0, 2.5]), np.array([0.5, 0.5])))
+        ctx = AnalyticContext(
+            events=self.events,
+            activities={(0, 1): (0, act0)},
+            precedence_list=((1, ((0, 0),)),),
+            max_delay=5.0,
+            step_size=1.0,
+        )
+        with self.assertRaises(ValueError):
+            create_discrete_simulator(ctx)
+
     def test_bounds_and_overflow(self) -> None:
         events = (
             ScheduledEvent("0", EventTimestamp(0.0, 100.0, 0.0), bounds=(0.0, 0.0)),


### PR DESCRIPTION
## Summary
- add `validate_alignment()` method to ensure PMF values conform to step grid
- check alignment in `AnalyticContext.validate`
- raise an error when activities contain misaligned PMFs
- test new validation in discrete simulator tests
- document alignment requirement in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685975ba748083229ee6a877d46d9c80