### PR TITLE
Optimize PMF extreme ops

### DIFF
--- a/test/test_pmf.py
+++ b/test/test_pmf.py
@@ -11,6 +11,20 @@ class TestDiscretePMF(unittest.TestCase):
         self.assertTrue(np.allclose(truncated.values, [0.5]))
         self.assertTrue(np.allclose(truncated.probs, [1.0]))
 
+    def test_maximum_aligned(self) -> None:
+        pmf_a = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]))
+        pmf_b = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]))
+        result = pmf_a.maximum(pmf_b)
+        self.assertTrue(np.allclose(result.values, [0.0, 1.0]))
+        self.assertTrue(np.allclose(result.probs, [0.25, 0.75]))
+
+    def test_minimum_aligned_offset(self) -> None:
+        pmf_a = DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5]))
+        pmf_b = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]))
+        result = pmf_a.minimum(pmf_b)
+        self.assertTrue(np.allclose(result.values, [0.0, 1.0, 2.0]))
+        self.assertTrue(np.allclose(result.probs, [0.5, 0.5, 0.0]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- improve DiscretePMF maximum/minimum for aligned PMFs
- ensure convolution fallback keeps values ordered
- adapt simulator tests for updated validation rules
- enforce alignment requirement for extrema operations

## Testing
- `python setup.py build_ext --inplace`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859790f7bc8832286547f2a81efeb78