### PR TITLE
Add optional validation when creating discrete simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,11 @@ print(pmfs[1].values, pmfs[1].probs)
 This computes event-time PMFs deterministically without Monte-Carlo sampling.
 
 The ``step_size`` sets the spacing for all values in the discrete PMFs.
-``DiscreteSimulator`` invokes ``AnalyticContext.validate()`` at construction
-time and will raise an error when any edge uses a different step.  All PMF
-value grids must therefore have constant spacing equal to ``step_size`` and
-start on a multiple of that step.
+By default ``create_discrete_simulator()`` calls ``AnalyticContext.validate()``
+before constructing the simulator and raises an error when any edge uses a
+different step. All PMF value grids must therefore have constant spacing equal
+to ``step_size`` and start on a multiple of that step. Pass ``validate=False``
+to skip this check if you have already validated the context yourself.
 Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
 resulting distribution. Overflow and underflow mass can either be truncated to
 the closest bound or removed entirely. Control this behaviour via the optional

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -52,10 +52,24 @@ def create_discrete_simulator(
     *,
     underflow_rule: UnderflowRule = UnderflowRule.TRUNCATE,
     overflow_rule: OverflowRule = OverflowRule.TRUNCATE,
+    validate: bool = True,
 ) -> "DiscreteSimulator":
-    """Return a :class:`DiscreteSimulator` with topology built for ``context``."""
+    """Return a :class:`DiscreteSimulator` with topology built for ``context``.
 
-    context.validate()
+    Parameters
+    ----------
+    context:
+        Analytic description of the DAG to simulate.
+    underflow_rule, overflow_rule:
+        How to handle probability mass outside event bounds.
+    validate:
+        When ``True`` (default), ``context.validate()`` is invoked before
+        creating the simulator. Set to ``False`` if the caller guarantees that
+        the context is already valid.
+    """
+
+    if validate:
+        context.validate()
     preds, order = build_topology(context)
     return DiscreteSimulator(
         context=context,

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -92,6 +92,21 @@ class TestDiscreteSimulator(unittest.TestCase):
         with self.assertRaises(ValueError):
             create_discrete_simulator(ctx)
 
+    def test_skip_validation(self) -> None:
+        act0 = AnalyticEdge(DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5])))
+        ctx = AnalyticContext(
+            events=self.events,
+            activities={(0, 1): (0, act0)},
+            precedence_list=((1, ((0, 0),)),),
+            max_delay=5.0,
+            step_size=2.0,
+        )
+
+        # Should not raise when validation is disabled
+        sim = create_discrete_simulator(ctx, validate=False)
+        result = sim.run()
+        self.assertEqual(len(result), 3)
+
     def test_misaligned_values(self) -> None:
         act0 = AnalyticEdge(DiscretePMF(np.array([1.0, 2.5]), np.array([0.5, 0.5])))
         ctx = AnalyticContext(


### PR DESCRIPTION
## Summary
- add `validate` parameter to `create_discrete_simulator`
- document the new parameter in README
- allow skipping validation through new unit test

## Testing
- `python test/test_simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6859830a4cb88322b6bb2f6e710003d1