### PR TITLE
Clarify overflow rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,12 @@ different step. All PMF value grids must therefore have constant spacing equal
 to ``step_size`` and start on a multiple of that step. Pass ``validate=False``
 to skip this check if you have already validated the context yourself.
 Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
-resulting distribution. Overflow and underflow mass can either be truncated to
-the closest bound or removed entirely. Control this behaviour via the optional
-``underflow_rule`` and ``overflow_rule`` arguments of
-``create_discrete_simulator()``. The ``run()`` method returns a sequence of
+resulting distribution. Overflow and underflow mass can be truncated to the
+closest bound, removed or redistributed across the remaining range. Control this
+behaviour via the optional ``underflow_rule`` and ``overflow_rule`` arguments of
+``create_discrete_simulator()``. ``TRUNCATE`` places the mass on the bound,
+``REMOVE`` drops it entirely and ``REDISTRIBUTE`` reweights the other values.
+The ``run()`` method returns a sequence of
 ``SimulatedEvent`` objects which hold the resulting PMF and the probability mass
 discarded on either side. Events without predecessors are deterministic and
 their PMFs collapse to a single value at the earliest bound.

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -78,9 +78,11 @@ class AnalyticContext:
 
 @unique
 class UnderflowRule(IntEnum):
-    """How to handle probability mass below a lower bound."""
+    """Policy for mass falling below the lower bound.
 
-    # TODO: Explain meaning of each rule better
+    ``TRUNCATE`` assigns it to the bound value, ``REMOVE`` drops it entirely and
+    ``REDISTRIBUTE`` spreads it over the remaining probabilities.
+    """
 
     TRUNCATE = 1
     REMOVE = 2
@@ -89,9 +91,11 @@ class UnderflowRule(IntEnum):
 
 @unique
 class OverflowRule(IntEnum):
-    """How to handle probability mass above an upper bound."""
+    """Policy for mass exceeding the upper bound.
 
-    # TODO: Explain meaning of each rule better
+    ``TRUNCATE`` moves the excess to the bound, ``REMOVE`` discards it and
+    ``REDISTRIBUTE`` allocates it proportionally over the retained range.
+    """
 
     TRUNCATE = 1
     REMOVE = 2


### PR DESCRIPTION
## Summary
- document behavior of UnderflowRule & OverflowRule
- mention TRUNCATE/REMOVE/REDISTRIBUTE in README

## Testing
- `pip install -e .`
- `pytest -q` *(fails: cannot import name 'Second' due to circular import)*

------
https://chatgpt.com/codex/tasks/task_e_68599b2e41748322a6607b967cc13d9e