### PR TITLE
Fix pipeline script and circular imports

### DIFF
--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -15,8 +15,10 @@ from .discrete import (
     DiscretePMF,
     DiscreteSimulator,
     create_discrete_simulator,
+    UnderflowRule,
+    OverflowRule,
 )
-from . import UnderflowRule, OverflowRule
+
 from .utils.inspection import plot_activity_delays, retrieve_absolute_and_relative_delays
 
 __version__ = version("mc-dagprop")

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import NewType
 
-from .context import AnalyticContext, ScheduledEvent, SimulatedEvent, UnderflowRule, OverflowRule
-from .pmf import DiscretePMF
-from .simulator import DiscreteSimulator, create_discrete_simulator
-
 Second = NewType("Second", float)
 ProbabilityMass = NewType("ProbabilityMass", float)
 NodeIndex = NewType("NodeIndex", int)
 EdgeIndex = NewType("EdgeIndex", int)
+
+from .context import AnalyticContext, ScheduledEvent, SimulatedEvent, UnderflowRule, OverflowRule
+from .pmf import DiscretePMF
+from .simulator import DiscreteSimulator, create_discrete_simulator
 
 __all__ = [
     "DiscretePMF",

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from . import ProbabilityMass, Second, UnderflowRule, OverflowRule, NodeIndex, EdgeIndex
 from .context import AnalyticContext, PredecessorTuple, SimulatedEvent, validate_context
-from .. import DiscretePMF
+from .pmf import DiscretePMF
 
 
 def _build_topology(

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Delete old build artifacts
-rm -f dist/*
-rm -f build/*
+rm -rf dist/*
+rm -rf build/*
 
 
 poetry build


### PR DESCRIPTION
## Summary
- clean build artifacts with `rm -rf`
- define `NewType` aliases before importing context in discrete package
- import `DiscretePMF` locally in discrete simulator to avoid circular import
- import overflow and underflow rule from discrete package in root module

## Testing
- `./pipeline.sh > /tmp/pipeline.log 2>&1 && tail -n 20 /tmp/pipeline.log`

------
https://chatgpt.com/codex/tasks/task_e_68599bc9bd1c83228ef0e8a3ae14b3db