### PR TITLE
Fix variable names in simulator

### DIFF
--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from . import ProbabilityMass, Second, UnderflowRule, OverflowRule, NodeIndex, EdgeIndex
 from .context import AnalyticContext, PredecessorTuple, SimulatedEvent, validate_context
-from .. import DiscretePMF
+from .pmf import DiscretePMF
 
 
 def _build_topology(
@@ -185,4 +185,4 @@ class DiscreteSimulator:
         assert (
             sum(clipped.probabilities) + float(under_mass) + float(over_mass) <= 1.0
         ), "Total probability mass exceeds 1.0 after clipping"
-        return SimulatedEvent(clipped, underflow_mass, overflow_mass)
+        return SimulatedEvent(clipped, under_mass, over_mass)

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -208,5 +208,26 @@ class TestDiscreteSimulator(unittest.TestCase):
         self.assertTrue(all(e.overflow >= 0.0 for e in events_res))
 
 
+def test_run_returns_simulated_event_objects() -> None:
+    events = (
+        ScheduledEvent("0", EventTimestamp(0.0, 10.0, 0.0)),
+        ScheduledEvent("1", EventTimestamp(0.0, 10.0, 0.0)),
+    )
+    edge = AnalyticEdge(
+        DiscretePMF(np.array([-1.0, 0.0, 1.0, 2.0]), np.array([0.25, 0.25, 0.25, 0.25]), step=1.0)
+    )
+    ctx = AnalyticContext(
+        events=events,
+        activities={(0, 1): (0, edge)},
+        precedence_list=((1, ((0, 0),)),),
+        max_delay=5.0,
+        step_size=1.0,
+    )
+
+    sim = create_discrete_simulator(ctx)
+    result = sim.run()
+    assert all(isinstance(ev, SimulatedEvent) for ev in result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- use `under_mass` and `over_mass` when returning `SimulatedEvent`
- import `DiscretePMF` locally in `DiscreteSimulator`
- add regression test for `DiscreteSimulator.run`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Second' from partially initialized module 'mc_dagprop.discrete')*

------
https://chatgpt.com/codex/tasks/task_e_68599b3268948322a5c4ac9defcb5d94