### PR TITLE
Update DiscretePMF constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ events = (
     SimEvent("A", EventTimestamp(0, 10, 0)),
     SimEvent("B", EventTimestamp(0, 10, 0)),
 )
-activities = {(0, 1): (0, DiscretePMF([1.0, 2.0], [0.5, 0.5]))}
+activities = {(0, 1): (0, DiscretePMF([1.0, 2.0], [0.5, 0.5], step=1.0))}
 precedence = (
     (1, ((0, 0),)),
 )

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -104,7 +104,9 @@ class DiscreteSimulator:
             is_origin = predecessors is None
             if is_origin:
                 events[node_index] = SimulatedEvent(
-                    DiscretePMF.delta(ev.timestamp.earliest), ProbabilityMass(0.0), ProbabilityMass(0.0)
+                    DiscretePMF.delta(ev.timestamp.earliest, step=self.context.step_size),
+                    ProbabilityMass(0.0),
+                    ProbabilityMass(0.0),
                 )
                 continue
             assert len(predecessors) > 0, f"Event {node_index} has no predecessors, but is not an origin"
@@ -177,7 +179,7 @@ class DiscreteSimulator:
             # re-distribute the mass according to the probabilities
             new_probs = new_probs + to_add * (new_probs / new_probs.sum())
 
-        clipped = DiscretePMF(new_vals, new_probs)
+        clipped = DiscretePMF(new_vals, new_probs, step=self.context.step_size)
         # FIXME: This should be a validation method, outside of the apply_bounds method.
         clipped.validate()
 

--- a/test/test_pmf.py
+++ b/test/test_pmf.py
@@ -7,8 +7,8 @@ from mc_dagprop.discrete.pmf import DiscretePMF
 class TestDiscretePMF(unittest.TestCase):
 
     def test_maximum_aligned(self) -> None:
-        pmf_a = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]))
-        pmf_b = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]))
+        pmf_a = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]), step=1.0)
+        pmf_b = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]), step=1.0)
         result = pmf_a.maximum(pmf_b)
         self.assertTrue(np.allclose(result.values, [0.0, 1.0]))
         self.assertTrue(np.allclose(result.probabilities, [0.25, 0.75]))


### PR DESCRIPTION
## Summary
- require explicit `step` parameter for `DiscretePMF`
- update validation to check alignment
- adjust simulator and tests for new step argument
- document step usage in README examples

## Testing
- `pytest -q` *(fails: PMF grid spacing does not match step and other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68599f97169c8322b5b0530e75b5414e