### PR TITLE
Validate non-positive step size

### DIFF
--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -107,6 +107,9 @@ def validate_context(context: AnalyticContext) -> None:
 
     n_events = len(context.events)
 
+    if context.step_size <= 0.0:
+        raise ValueError("step_size must be positive")
+
     # Validate scheduled events
     for i, ev in enumerate(context.events):
         ts = ev.timestamp

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -94,6 +94,18 @@ class TestDiscreteSimulator(unittest.TestCase):
         with self.assertRaises(ValueError):
             create_discrete_simulator(ctx)
 
+    def test_non_positive_step_size(self) -> None:
+        ctx = AnalyticContext(
+            events=self.events,
+            activities={},
+            precedence_list=(),
+            step_size=0.0,
+            underflow_rule=UnderflowRule.TRUNCATE,
+            overflow_rule=OverflowRule.TRUNCATE,
+        )
+        with self.assertRaises(ValueError):
+            create_discrete_simulator(ctx)
+
     def test_skip_validation(self) -> None:
         act0 = AnalyticEdge(0, DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5]), step=1.0))
         ctx = AnalyticContext(


### PR DESCRIPTION
## Summary
- check for step_size <= 0 in `validate_context`
- add test case for invalid step_size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859adab54248322ba351992a735e2e0