### PR TITLE
Centralize type definitions

### DIFF
--- a/mc_dagprop/_core.pyi
+++ b/mc_dagprop/_core.pyi
@@ -1,14 +1,16 @@
 # mc_dagprop/_core.pyi
 from collections.abc import Collection, Iterable, Mapping, Sequence
-from typing import TypeAlias
+from mc_dagprop.types import (
+    ActivityIndex,
+    ActivityType,
+    EventId,
+    EventIndex,
+    Second,
+)
 
 from numpy._typing import NDArray
 
-EventIndex: TypeAlias = int
-ActivityIndex: TypeAlias = int
-ActivityType: TypeAlias = int
-EventId: TypeAlias = str
-Second: TypeAlias = float
+
 
 class SimEvent:
     """

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-from typing import NewType
-
-Second = NewType("Second", float)
-ProbabilityMass = NewType("ProbabilityMass", float)
-NodeIndex = NewType("NodeIndex", int)
-EdgeIndex = NewType("EdgeIndex", int)
+from mc_dagprop.types import EdgeIndex, NodeIndex, ProbabilityMass, Second
 
 from .context import AnalyticContext, ScheduledEvent, SimulatedEvent, UnderflowRule, OverflowRule
 from .pmf import DiscretePMF

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -6,7 +6,7 @@ from enum import unique, IntEnum
 import numpy as np
 
 from mc_dagprop import EventTimestamp
-from . import Second, ProbabilityMass, NodeIndex, EdgeIndex
+from mc_dagprop.types import EdgeIndex, NodeIndex, ProbabilityMass, Second
 from .pmf import DiscretePMF
 
 PredecessorTuple = tuple[NodeIndex, EdgeIndex]

--- a/mc_dagprop/discrete/pmf.py
+++ b/mc_dagprop/discrete/pmf.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from mc_dagprop.discrete import Second, ProbabilityMass
+from mc_dagprop.types import ProbabilityMass, Second
 
 
 @dataclass(frozen=True, slots=True)

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from . import ProbabilityMass, Second, UnderflowRule, OverflowRule, NodeIndex, EdgeIndex
+from mc_dagprop.types import EdgeIndex, NodeIndex, ProbabilityMass, Second
+from . import OverflowRule, UnderflowRule
 from .context import AnalyticContext, PredecessorTuple, SimulatedEvent, validate_context
 from .pmf import DiscretePMF
 

--- a/mc_dagprop/types.py
+++ b/mc_dagprop/types.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import NewType
+
+__all__ = [
+    "Second",
+    "ProbabilityMass",
+    "NodeIndex",
+    "EdgeIndex",
+    "EventIndex",
+    "ActivityIndex",
+    "ActivityType",
+    "EventId",
+]
+
+Second = NewType("Second", float)
+ProbabilityMass = NewType("ProbabilityMass", float)
+
+NodeIndex = NewType("NodeIndex", int)
+EdgeIndex = NewType("EdgeIndex", int)
+
+EventIndex = NewType("EventIndex", int)
+ActivityIndex = NewType("ActivityIndex", int)
+ActivityType = NewType("ActivityType", int)
+EventId = NewType("EventId", str)


### PR DESCRIPTION
## Summary
- move all common type definitions to `mc_dagprop/types.py`
- update modules to import types from the new module
- keep exported names stable in `discrete.__init__`
- define shared types consistently with `typing.NewType`

## Testing
- `bash pipeline.sh`


------
https://chatgpt.com/codex/tasks/task_e_6859b75230288322bd545835799ccc3b