### PR TITLE
Add example package

### DIFF
--- a/example/_shared.py
+++ b/example/_shared.py
@@ -8,7 +8,6 @@ from mc_dagprop import (
     DiscretePMF,
     EventTimestamp,
     ScheduledEvent,
-    create_discrete_simulator,
     UnderflowRule,
     OverflowRule,
 )
@@ -114,19 +113,3 @@ def build_example_context(cfg: ExampleConfig = ExampleConfig()) -> AnalyticConte
         underflow_rule=UnderflowRule.TRUNCATE,
         overflow_rule=OverflowRule.TRUNCATE,
     )
-
-
-def main() -> None:
-    ctx = build_example_context()
-    sim = create_discrete_simulator(ctx)
-    results = sim.run()
-
-    for sched, result in zip(ctx.events, results):
-        print(f"{sched.id}:")
-        print(f"  values: {result.pmf.values}")
-        print(f"  probs:  {result.pmf.probabilities}")
-        print(f"  underflow: {float(result.underflow)} overflow: {float(result.overflow)}\n")
-
-
-if __name__ == "__main__":
-    main()

--- a/example/discrete_example.py
+++ b/example/discrete_example.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from mc_dagprop import create_discrete_simulator
+
+from ._shared import ExampleConfig, build_example_context
+
+
+def main() -> None:
+    ctx = build_example_context()
+    sim = create_discrete_simulator(ctx)
+    results = sim.run()
+
+    for sched, result in zip(ctx.events, results):
+        print(f"{sched.id}:")
+        print(f"  values: {result.pmf.values}")
+        print(f"  probs:  {result.pmf.probabilities}")
+        print(f"  underflow: {float(result.underflow)} overflow: {float(result.overflow)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/mc_example.py
+++ b/example/mc_example.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Sequence
+import numpy as np
+
+from mc_dagprop import (
+    GenericDelayGenerator,
+    SimActivity,
+    SimContext,
+    SimEvent,
+    Simulator,
+)
+from ._shared import ExampleConfig, build_example_context
+
+
+@dataclass(frozen=True)
+class MonteCarloConfig(ExampleConfig):
+    """Configuration for the Monte Carlo demonstration."""
+
+    trials: int = 1000
+    max_delay: float = 20.0
+
+
+def build_mc_simulator(context_cfg: ExampleConfig, max_delay: float) -> Simulator:
+    """Return a :class:`Simulator` mirroring the analytic example."""
+
+    analytic_ctx = build_example_context(context_cfg)
+    events = [SimEvent(ev.id, ev.timestamp) for ev in analytic_ctx.events]
+
+    activities: dict[tuple[int, int], tuple[int, SimActivity]] = {}
+    generator = GenericDelayGenerator()
+
+    for (src, dst), (edge_idx, edge) in analytic_ctx.activities.items():
+        activities[(src, dst)] = (edge_idx, SimActivity(0.0, edge_idx))
+        pmf = edge.pmf
+        generator.add_empirical_absolute(
+            edge_idx,
+            pmf.values.tolist(),
+            pmf.probabilities.tolist(),
+        )
+
+    mc_ctx = SimContext(
+        events=events,
+        activities=activities,
+        precedence_list=analytic_ctx.precedence_list,
+        max_delay=max_delay,
+    )
+
+    return Simulator(mc_ctx, generator)
+
+
+def run_trials(sim: Simulator, seeds: Sequence[int]) -> np.ndarray:
+    """Run ``sim`` for each seed and return realized times."""
+
+    results = sim.run_many(seeds)
+    return np.array([res.realized for res in results])
+
+
+def main() -> None:
+    cfg = MonteCarloConfig()
+    sim = build_mc_simulator(cfg, cfg.max_delay)
+    samples = run_trials(sim, range(cfg.trials))
+    analytic = build_example_context(cfg)
+
+    for idx, sched in enumerate(analytic.events):
+        values, counts = np.unique(samples[:, idx], return_counts=True)
+        probs = counts / cfg.trials
+        print(f"{sched.id}:")
+        print(f"  values: {values}")
+        print(f"  probs:  {probs}")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restructure demonstration code under an `example` package
- split shared analytic context to `_shared.py`
- provide `mc_example` and `discrete_example` scripts

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_6859b73716548322802d6bf662d7136d