### PR TITLE
Unify DAG dataclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,28 +63,28 @@ pip install mc-dagprop
 ```python
 from mc_dagprop import (
     EventTimestamp,
-    SimEvent,
-    SimActivity,
-    SimContext,
+    Event,
+    Activity,
+    DagContext,
     GenericDelayGenerator,
     Simulator,
 )
 
 # 1) Build your DAG timing context
 events = [
-    SimEvent("A", EventTimestamp(0.0, 100.0, 0.0)),
-    SimEvent("B", EventTimestamp(10.0, 100.0, 0.0)),
+    Event("A", EventTimestamp(0.0, 100.0, 0.0)),
+    Event("B", EventTimestamp(10.0, 100.0, 0.0)),
 ]
 
 activities = {
-    (0, 1): (0, SimActivity(minimal_duration=60.0, activity_type=1)),
+    (0, 1): (0, Activity(minimal_duration=60.0, activity_type=1)),
 }
 
 precedence = [
     (1, [(0, 0)]),
 ]
 
-ctx = SimContext(
+ctx = DagContext(
     events=events,
     activities=activities,
     precedence_list=precedence,
@@ -115,26 +115,26 @@ Holds the scheduling window and actual time for one event (node):
 - `latest`   – latest allowed occurrence  
 - `actual`   – scheduled (baseline) timestamp  
 
-### `SimEvent(id: str, timestamp: EventTimestamp)`
+### `Event(id: str, timestamp: EventTimestamp)`
 
 Wraps a DAG node with:
 
 - `id`        – string key for the node  
 - `timestamp` – an `EventTimestamp` instance  
 
-### `SimActivity(minimal_duration: float, activity_type: int)`
+### `Activity(minimal_duration: float, activity_type: int)`
 
 Represents an edge in the DAG:
 
 - `minimal_duration` – minimal (base) duration  
 - `activity_type`    – integer type identifier  
 
-### `SimContext(events, activities, precedence_list, max_delay)`
+### `DagContext(events, activities, precedence_list, max_delay)`
 
 Container for your DAG:
 
-- `events`:          `list[SimEvent]`
-- `activities`:      `dict[(src_idx, dst_idx), (link_idx, SimActivity)]`
+- `events`:          `list[Event]`
+- `activities`:      `dict[(src_idx, dst_idx), (link_idx, Activity)]`
 - `precedence_list`: `list[(target_idx, [(pred_idx, link_idx), …])]`
 - `max_delay`:       overall cap on delay propagation
   - Can be given in any order. `Simulator` will sort topologically and raise
@@ -151,7 +151,7 @@ Configurable delay factory (one distribution per `activity_type`):
 - `.add_empirical_relative(activity_type, factors, weights)`
 - `.set_seed(seed)`  
 
-### `Simulator(context: SimContext, generator: GenericDelayGenerator)`
+### `Simulator(context: DagContext, generator: GenericDelayGenerator)`
 
 - `.run(seed: int) → SimResult`  
 - `.run_many(seeds: Sequence[int]) → list[SimResult]`  
@@ -172,13 +172,13 @@ from mc_dagprop import (
     AnalyticContext,
     DiscretePMF,
     EventTimestamp,
-    SimEvent,
+    Event,
     create_discrete_simulator,
 )
 
 events = (
-    SimEvent("A", EventTimestamp(0, 10, 0)),
-    SimEvent("B", EventTimestamp(0, 10, 0)),
+    Event("A", EventTimestamp(0, 10, 0)),
+    Event("B", EventTimestamp(0, 10, 0)),
 )
 activities = {(0, 1): (0, DiscretePMF([1.0, 2.0], [0.5, 0.5], step=1.0))}
 precedence = (

--- a/benchmarks/benchmark_simulator.py
+++ b/benchmarks/benchmark_simulator.py
@@ -7,27 +7,27 @@ import random
 import time
 from collections.abc import Iterable
 
-from mc_dagprop import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, Simulator
+from mc_dagprop import EventTimestamp, GenericDelayGenerator, Activity, DagContext, Event, Simulator
 
 # Use a reasonably large graph similar to the one used in the tests
 N_NODES = 10_000
 
 
-def build_context() -> SimContext:
-    events = [SimEvent(str(i), EventTimestamp(float(i), 100.0 + i, 0.0)) for i in range(N_NODES)]
-    link_map = {(i, i + 1): (i, SimActivity(3.0 + random.random(), 1)) for i in range(N_NODES - 1)}
+def build_context() -> DagContext:
+    events = [Event(str(i), EventTimestamp(float(i), 100.0 + i, 0.0)) for i in range(N_NODES)]
+    link_map = {(i, i + 1): (i, Activity(3.0 + random.random(), 1)) for i in range(N_NODES - 1)}
     precedence_list = [(i, [(i - 1, i)]) for i in range(1, N_NODES)]
-    return SimContext(events=events, activities=link_map, precedence_list=precedence_list, max_delay=10.0)
+    return DagContext(events=events, activities=link_map, precedence_list=precedence_list, max_delay=10.0)
 
 
-def build_constant_sim(ctx: SimContext) -> Simulator:
+def build_constant_sim(ctx: DagContext) -> Simulator:
     """Simulator with constant delay distribution."""
     gen = GenericDelayGenerator()
     gen.add_constant(activity_type=1, factor=1.0)
     return Simulator(ctx, gen)
 
 
-def build_exponential_sim(ctx: SimContext) -> Simulator:
+def build_exponential_sim(ctx: DagContext) -> Simulator:
     """Simulator with exponential delay distribution."""
     gen = GenericDelayGenerator()
     gen.add_exponential(activity_type=1, lambda_=0.1, max_scale=1.0)

--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -3,14 +3,13 @@
 from importlib.metadata import version
 
 try:
-    from ._core import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, SimResult, Simulator
+    from ._core import Activity, DagContext, Event, EventTimestamp, GenericDelayGenerator, SimResult, Simulator
 except ModuleNotFoundError as exc:  # pragma: no cover - compiled module missing
     raise ImportError(
         "mc_dagprop requires the compiled extension 'mc_dagprop._core'. " "Install the package from source to build it."
     ) from exc
 from .discrete import (
     AnalyticContext,
-    ScheduledEvent,
     SimulatedEvent,
     DiscretePMF,
     DiscreteSimulator,
@@ -25,14 +24,13 @@ __version__ = version("mc-dagprop")
 
 __all__ = [
     "GenericDelayGenerator",
-    "SimContext",
+    "DagContext",
     "SimResult",
-    "SimEvent",
-    "SimActivity",
+    "Event",
+    "Activity",
     "Simulator",
     "EventTimestamp",
     "DiscretePMF",
-    "ScheduledEvent",
     "SimulatedEvent",
     "UnderflowRule",
     "OverflowRule",

--- a/mc_dagprop/_core.pyi
+++ b/mc_dagprop/_core.pyi
@@ -1,18 +1,13 @@
 # mc_dagprop/_core.pyi
 from collections.abc import Collection, Iterable, Mapping, Sequence
-from mc_dagprop.types import (
-    ActivityIndex,
-    ActivityType,
-    EventId,
-    EventIndex,
-    Second,
-)
+from mc_dagprop.types import ActivityIndex, ActivityType, EventId, EventIndex, Second
+from mc_dagprop.core import Activity as CoreActivity, DagContext as CoreDagContext, Event as CoreEvent, EventTimestamp
 
 from numpy._typing import NDArray
 
 
 
-class SimEvent:
+class Event(CoreEvent):
     """
     Represents an event (node) with its earliest/latest window and actual timestamp.
     """
@@ -22,18 +17,8 @@ class SimEvent:
 
     def __init__(self, id_: EventId, timestamp: "EventTimestamp") -> None: ...
 
-class EventTimestamp:
-    """
-    Holds the earliest/latest bounds and the actual (scheduled) time for an event.
-    """
 
-    earliest: Second
-    latest: Second
-    actual: Second
-
-    def __init__(self, earliest: Second, latest: Second, actual: Second) -> None: ...
-
-class SimActivity:
+class Activity(CoreActivity):
     """
     Represents an activity (edge) in the DAG, with its minimal duration and type.
     """
@@ -43,22 +28,22 @@ class SimActivity:
 
     def __init__(self, minimal_duration: Second, activity_type: ActivityType) -> None: ...
 
-class SimContext:
+class DagContext(CoreDagContext):
     """
     Wraps the DAG: a list of events, activities, a precedence list and a
     max?delay. ``precedence_list`` can be in any order; ``Simulator`` sorts it
     topologically and raises ``RuntimeError`` on cycles.
     """
 
-    events: Sequence[SimEvent]
-    activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, SimActivity]]
+    events: Sequence[Event]
+    activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, Activity]]
     precedence_list: Sequence[tuple[EventIndex, list[tuple[EventIndex, ActivityIndex]]]]
     max_delay: Second
 
     def __init__(
         self,
-        events: Sequence[SimEvent],
-        activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, SimActivity]],
+        events: Sequence[Event],
+        activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, Activity]],
         precedence_list: Sequence[tuple[EventIndex, list[tuple[EventIndex, ActivityIndex]]]],
         max_delay: Second,
     ) -> None: ...
@@ -95,10 +80,10 @@ class GenericDelayGenerator:
 class Simulator:
     """
     Monte Carlo DAG propagator: run single or batch simulations. ``precedence_list``
-    in the provided ``SimContext`` may be in any order; it is sorted topologically
+    in the provided ``DagContext`` may be in any order; it is sorted topologically
     and a ``RuntimeError`` is raised if cycles are detected.
     """
 
-    def __init__(self, context: SimContext, generator: GenericDelayGenerator) -> None: ...
+    def __init__(self, context: DagContext, generator: GenericDelayGenerator) -> None: ...
     def run(self, seed: int) -> SimResult: ...
     def run_many(self, seeds: Iterable[int]) -> list[SimResult]: ...

--- a/mc_dagprop/core.py
+++ b/mc_dagprop/core.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+
+from .types import ActivityIndex, ActivityType, EventId, EventIndex, Second
+
+
+__all__ = ["EventTimestamp", "Event", "Activity", "DagContext"]
+
+
+@dataclass(slots=True, frozen=True)
+class EventTimestamp:
+    """Scheduling bounds and baseline timestamp for an event."""
+
+    earliest: Second
+    latest: Second
+    actual: Second
+
+
+@dataclass(slots=True, frozen=True)
+class Event:
+    """Node with identifier and timing information."""
+
+    id: EventId
+    timestamp: EventTimestamp
+
+
+@dataclass(slots=True, frozen=True)
+class Activity:
+    """Edge definition with minimal duration and type identifier."""
+
+    minimal_duration: Second
+    activity_type: ActivityType
+
+
+@dataclass(slots=True, frozen=True)
+class DagContext:
+    """Container describing a DAG for simulation."""
+
+    events: Sequence[Event]
+    activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, Activity]]
+    precedence_list: Sequence[tuple[EventIndex, Sequence[tuple[EventIndex, ActivityIndex]]]]
+    max_delay: Second

--- a/mc_dagprop/discrete/__init__.py
+++ b/mc_dagprop/discrete/__init__.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from mc_dagprop.types import EdgeIndex, NodeIndex, ProbabilityMass, Second
 
-from .context import AnalyticContext, ScheduledEvent, SimulatedEvent, UnderflowRule, OverflowRule
+from .context import AnalyticContext, SimulatedEvent, UnderflowRule, OverflowRule
 from .pmf import DiscretePMF
 from .simulator import DiscreteSimulator, create_discrete_simulator
 
 __all__ = [
     "DiscretePMF",
-    "ScheduledEvent",
     "SimulatedEvent",
     "UnderflowRule",
     "OverflowRule",

--- a/mc_dagprop/discrete/context.py
+++ b/mc_dagprop/discrete/context.py
@@ -5,7 +5,7 @@ from enum import unique, IntEnum
 
 import numpy as np
 
-from mc_dagprop import EventTimestamp
+from mc_dagprop.core import Event, EventTimestamp
 from mc_dagprop.types import EdgeIndex, NodeIndex, ProbabilityMass, Second
 from .pmf import DiscretePMF
 
@@ -24,22 +24,6 @@ class AnalyticEdge:
     pmf: DiscretePMF
 
 
-@dataclass(frozen=True, slots=True)
-class ScheduledEvent:
-    """Timing information for a planned event.
-
-    Attributes:
-        id: Unique identifier of the event.
-        timestamp: Earliest, latest and nominal time bounds.
-    """
-
-    id: str
-    timestamp: EventTimestamp
-
-    @property
-    def bounds(self) -> tuple[Second, Second]:
-        """Return the lower and upper bounds of the event."""
-        return self.timestamp.earliest, self.timestamp.latest
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,7 +52,7 @@ class AnalyticContext:
         step_size: Discrete time step shared by all distributions.
     """
 
-    events: tuple[ScheduledEvent, ...]
+    events: tuple[Event, ...]
     activities: dict[tuple[NodeIndex, NodeIndex], tuple[EdgeIndex, AnalyticEdge]]
     precedence_list: tuple[tuple[NodeIndex, tuple[PredecessorTuple, ...]], ...]
     step_size: Second

--- a/mc_dagprop/discrete/simulator.py
+++ b/mc_dagprop/discrete/simulator.py
@@ -123,7 +123,7 @@ class DiscreteSimulator:
                 for next_pmf in to_combine[1:]:
                     resulting_pmf = resulting_pmf.maximum(next_pmf)
 
-            lb, ub = ev.bounds
+            lb, ub = ev.timestamp.earliest, ev.timestamp.latest
             events[node_index] = self._convert_to_simulated_event(resulting_pmf, lb, ub)
 
         return tuple(events[i] for i in range(n_events))

--- a/mc_dagprop/utils/demonstration.py
+++ b/mc_dagprop/utils/demonstration.py
@@ -3,7 +3,7 @@ import argparse
 from collections.abc import Iterable, Mapping
 
 import plotly.graph_objects as go
-from mc_dagprop import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, Simulator
+from mc_dagprop import EventTimestamp, GenericDelayGenerator, Activity, DagContext, Event, Simulator
 
 
 def simulate_and_collect(
@@ -17,10 +17,10 @@ def simulate_and_collect(
     realized timestamp of the second (delayed) node.
     """
     # simple 2-node DAG: A -> B
-    events = [SimEvent("A", EventTimestamp(0.0, 0.0, 0.0)), SimEvent("B", EventTimestamp(0.0, 0.0, 0.0))]
-    activities = {(0, 1): (0, SimActivity(minimal_duration=base_duration, activity_type=1))}
+    events = [Event("A", EventTimestamp(0.0, 0.0, 0.0)), Event("B", EventTimestamp(0.0, 0.0, 0.0))]
+    activities = {(0, 1): (0, Activity(minimal_duration=base_duration, activity_type=1))}
     precedence = [(1, [(0, 0)])]
-    ctx = SimContext(events, activities, precedence, max_delay=1e6)
+    ctx = DagContext(events, activities, precedence, max_delay=1e6)
 
     gen = GenericDelayGenerator()
     # configure this single activity_type=1 with the requested distribution

--- a/mc_dagprop/utils/inspection.py
+++ b/mc_dagprop/utils/inspection.py
@@ -3,12 +3,12 @@ from collections import defaultdict
 from collections.abc import Collection
 
 import plotly.graph_objects as go
-from mc_dagprop import SimContext, SimResult
+from mc_dagprop import DagContext, SimResult
 from plotly.subplots import make_subplots
 
 
 def retrieve_absolute_and_relative_delays(
-    context: SimContext, result: SimResult
+    context: DagContext, result: SimResult
 ) -> tuple[dict[int, list[float]], dict[int, list[float]]]:
     """
     Bucket absolute and relative delays by activity_type.
@@ -27,7 +27,7 @@ def retrieve_absolute_and_relative_delays(
     return dict(absolute_delays_by_type), dict(relative_delays_by_type)
 
 
-def plot_activity_delays(context: SimContext, results: Collection[SimResult]) -> go.Figure:
+def plot_activity_delays(context: DagContext, results: Collection[SimResult]) -> go.Figure:
     """
     Build a Plotly figure with two rows of histograms per activity type:
       • row 1: absolute delays

--- a/test/test_simulator.py
+++ b/test/test_simulator.py
@@ -3,33 +3,33 @@ from concurrent.futures import ThreadPoolExecutor
 from itertools import chain
 
 import numpy as np
-from mc_dagprop import EventTimestamp, GenericDelayGenerator, SimActivity, SimContext, SimEvent, Simulator
+from mc_dagprop import EventTimestamp, GenericDelayGenerator, Activity, DagContext, Event, Simulator
 
 
 class TestSimulator(unittest.TestCase):
     def setUp(self) -> None:
         self.events = [
-            SimEvent("0", EventTimestamp(0.0, 100.0, 0.0)),
-            SimEvent("1", EventTimestamp(5.0, 100.0, 0.0)),
-            SimEvent("2", EventTimestamp(10.0, 100.0, 0.0)),
-            SimEvent("3", EventTimestamp(22.0, 100.0, 0.0)),
-            SimEvent("4", EventTimestamp(20.0, 100.0, 0.0)),
-            SimEvent("5", EventTimestamp(100.0, 100.0, 0.0)),
+            Event("0", EventTimestamp(0.0, 100.0, 0.0)),
+            Event("1", EventTimestamp(5.0, 100.0, 0.0)),
+            Event("2", EventTimestamp(10.0, 100.0, 0.0)),
+            Event("3", EventTimestamp(22.0, 100.0, 0.0)),
+            Event("4", EventTimestamp(20.0, 100.0, 0.0)),
+            Event("5", EventTimestamp(100.0, 100.0, 0.0)),
         ]
 
-        # 2 links: (src, dst) ? SimActivity)
+        # 2 links: (src, dst) -> Activity
         self.link_map = {
-            (0, 1): (0, SimActivity(3.0, 1)),
-            (1, 2): (1, SimActivity(5.0, 1)),
-            (1, 3): (2, SimActivity(5.0, 1)),
-            (2, 4): (3, SimActivity(15.0, 2)),
-            (3, 4): (4, SimActivity(10.0, 3)),
+            (0, 1): (0, Activity(3.0, 1)),
+            (1, 2): (1, Activity(5.0, 1)),
+            (1, 3): (2, Activity(5.0, 1)),
+            (2, 4): (3, Activity(15.0, 2)),
+            (3, 4): (4, Activity(10.0, 3)),
         }
 
         # Precedence: node_idx ? [(pred_idx, link_idx)]
         self.precedence_list = [(1, [(0, 0)]), (2, [(1, 1)]), (3, [(1, 2)]), (4, [(2, 3), (3, 4)])]
 
-        self.context = SimContext(
+        self.context = DagContext(
             events=self.events, activities=self.link_map, precedence_list=self.precedence_list, max_delay=10.0
         )
 
@@ -62,7 +62,7 @@ class TestSimulator(unittest.TestCase):
 
     def test_unsorted_precedence_same_result(self):
         unsorted = list(reversed(self.precedence_list))
-        ctx_unsorted = SimContext(
+        ctx_unsorted = DagContext(
             events=self.events, activities=self.link_map, precedence_list=unsorted, max_delay=10.0
         )
 
@@ -173,10 +173,10 @@ class TestSimulator(unittest.TestCase):
 
 class LargeScaleTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.events = [SimEvent(str(i), EventTimestamp(float(i), 100.0 + i, 0.0)) for i in range(10_000)]
-        self.link_map = {(i, i + 1): (i, SimActivity(3.0, 1)) for i in range(9999)}
+        self.events = [Event(str(i), EventTimestamp(float(i), 100.0 + i, 0.0)) for i in range(10_000)]
+        self.link_map = {(i, i + 1): (i, Activity(3.0, 1)) for i in range(9999)}
         self.precedence_list = [(i, [(i - 1, i)]) for i in range(1, 10_000)]
-        self.context = SimContext(
+        self.context = DagContext(
             events=self.events, activities=self.link_map, precedence_list=self.precedence_list, max_delay=10.0
         )
 


### PR DESCRIPTION
## Summary
- add shared dataclasses in `mc_dagprop.core`
- rename Monte Carlo classes to `Event`, `Activity` and `DagContext`
- refactor analytic context to reuse these dataclasses
- update documentation, examples and tests

## Testing
- `bash pipeline.sh`
- `python test/test_simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_685a3f68356c832296861796116eee25