### PR TITLE
Rename simulator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ Configurable delay factory (one distribution per `activity_type`):
 - `.durations`:  `NDArray[float]` – per-edge durations (base + extra)  
 - `.cause_event`: `NDArray[int]` – which predecessor caused each event  
 
-## Discrete Simulator
+## Analytic Propagator
 
-You can propagate discrete delay distributions analytically using `DiscreteSimulator`.
+You can propagate discrete delay distributions analytically using `AnalyticPropagator`.
 Define per-edge probability mass functions and build an `AnalyticContext`:
 
 ```python
@@ -173,7 +173,7 @@ from mc_dagprop import (
     DiscretePMF,
     EventTimestamp,
     Event,
-    create_discrete_simulator,
+    create_analytic_propagator,
 )
 
 events = (
@@ -191,14 +191,14 @@ ctx = AnalyticContext(
     step_size=1.0,
 )
 
-sim = create_discrete_simulator(ctx)
+sim = create_analytic_propagator(ctx)
 pmfs = sim.run()
 print(pmfs[1].values, pmfs[1].probs)
 ```
 This computes event-time PMFs deterministically without Monte-Carlo sampling.
 
 The ``step_size`` sets the spacing for all values in the discrete PMFs.
-By default ``create_discrete_simulator()`` calls ``AnalyticContext.validate()``
+By default ``create_analytic_propagator()`` calls ``AnalyticContext.validate()``
 before constructing the simulator and raises an error when any edge uses a
 different step. All PMF value grids must therefore have constant spacing equal
 to ``step_size`` and start on a multiple of that step. Pass ``validate=False``
@@ -207,7 +207,7 @@ Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
 resulting distribution. Overflow and underflow mass can be truncated to the
 closest bound, removed or redistributed across the remaining range. Control this
 behaviour via the optional ``underflow_rule`` and ``overflow_rule`` arguments of
-``create_discrete_simulator()``. ``TRUNCATE`` places the mass on the bound,
+``create_analytic_propagator()``. ``TRUNCATE`` places the mass on the bound,
 ``REMOVE`` drops it entirely and ``REDISTRIBUTE`` reweights the other values.
 The ``run()`` method returns a sequence of
 ``SimulatedEvent`` objects which hold the resulting PMF and the probability mass

--- a/mc_dagprop/__init__.py
+++ b/mc_dagprop/__init__.py
@@ -10,8 +10,10 @@ except ModuleNotFoundError as exc:  # pragma: no cover - compiled module missing
     ) from exc
 from .analytic import (
     AnalyticContext,
+    AnalyticPropagator,
     SimulatedEvent,
     DiscretePMF,
+    create_analytic_propagator,
     DiscreteSimulator,
     create_discrete_simulator,
     UnderflowRule,
@@ -35,6 +37,8 @@ __all__ = [
     "UnderflowRule",
     "OverflowRule",
     "AnalyticContext",
+    "AnalyticPropagator",
+    "create_analytic_propagator",
     "DiscreteSimulator",
     "create_discrete_simulator",
     "plot_activity_delays",

--- a/mc_dagprop/analytic/__init__.py
+++ b/mc_dagprop/analytic/__init__.py
@@ -4,7 +4,12 @@ from mc_dagprop.types import EdgeIndex, NodeIndex, ProbabilityMass, Second
 
 from .context import AnalyticContext, SimulatedEvent, UnderflowRule, OverflowRule
 from .pmf import DiscretePMF
-from .simulator import DiscreteSimulator, create_discrete_simulator
+from .simulator import (
+    AnalyticPropagator,
+    create_analytic_propagator,
+    DiscreteSimulator,
+    create_discrete_simulator,
+)
 
 __all__ = [
     "DiscretePMF",
@@ -12,6 +17,8 @@ __all__ = [
     "UnderflowRule",
     "OverflowRule",
     "AnalyticContext",
+    "AnalyticPropagator",
+    "create_analytic_propagator",
     "DiscreteSimulator",
     "create_discrete_simulator",
     "Second",

--- a/mc_dagprop/analytic/pmf.py
+++ b/mc_dagprop/analytic/pmf.py
@@ -80,7 +80,7 @@ class DiscretePMF:
     def maximum(self, other: "DiscretePMF") -> "DiscretePMF":
         """Return ``max(X, Y)`` for two independent PMFs.
 
-        This operation is used by :class:`DiscreteSimulator` to combine delay
+        This operation is used by :class:`AnalyticPropagator` to combine delay
         distributions when an event has multiple predecessors.
         """
         if len(self.values) == 1 and len(other.values) == 1:

--- a/mc_dagprop/analytic/simulator.py
+++ b/mc_dagprop/analytic/simulator.py
@@ -44,8 +44,10 @@ def _build_topology(
     return tuple(preds_by_target), tuple(order)
 
 
-def create_discrete_simulator(context: AnalyticContext, validate: bool = True) -> "DiscreteSimulator":
-    """Return a :class:`DiscreteSimulator` with topology built for ``context``.
+def create_analytic_propagator(
+    context: AnalyticContext, validate: bool = True
+) -> "AnalyticPropagator":
+    """Return an :class:`AnalyticPropagator` with topology built for ``context``.
 
     Parameters
     ----------
@@ -61,11 +63,15 @@ def create_discrete_simulator(context: AnalyticContext, validate: bool = True) -
     if validate:
         validate_context(context)
     predecessors, order = _build_topology(context)
-    return DiscreteSimulator(context=context, _predecessors_by_target=predecessors, _topological_node_order=order)
+    return AnalyticPropagator(
+        context=context,
+        _predecessors_by_target=predecessors,
+        _topological_node_order=order,
+    )
 
 
 @dataclass(frozen=True, slots=True)
-class DiscreteSimulator:
+class AnalyticPropagator:
     """Propagate discrete PMFs through a DAG.
 
     Probability mass outside an event's bounds can either be truncated to the
@@ -199,3 +205,8 @@ class DiscreteSimulator:
         if total_mass > 1.0 and not np.isclose(total_mass, 1.0):
             raise ValueError("Total probability mass exceeds 1.0 after clipping")
         return SimulatedEvent(clipped, under_mass, over_mass)
+
+
+# Backward compatibility
+DiscreteSimulator = AnalyticPropagator
+create_discrete_simulator = create_analytic_propagator


### PR DESCRIPTION
## Summary
- rename class `DiscreteSimulator` to `AnalyticPropagator`
- rename factory to `create_analytic_propagator`
- export new names in package entry points
- update README and docstrings

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a46bd64408322b76af8371aecbc4f