### PR TITLE
Fix example imports and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ before constructing the simulator and raises an error when any edge uses a
 different step. All PMF value grids must therefore have constant spacing equal
 to ``step_size`` and start on a multiple of that step. Pass ``validate=False``
 to skip this check if you have already validated the context yourself.
-Each ``ScheduledEvent`` may specify ``bounds=(lower, upper)`` to clip the
+Each ``Event`` may specify ``bounds=(lower, upper)`` to clip the
 resulting distribution. Overflow and underflow mass can be truncated to the
 closest bound, removed or redistributed across the remaining range. Control this
 behaviour via the optional ``underflow_rule`` and ``overflow_rule`` arguments of

--- a/example/_shared.py
+++ b/example/_shared.py
@@ -6,8 +6,8 @@ import numpy as np
 from mc_dagprop import (
     AnalyticContext,
     DiscretePMF,
+    Event,
     EventTimestamp,
-    ScheduledEvent,
     UnderflowRule,
     OverflowRule,
 )
@@ -25,16 +25,16 @@ def build_example_context(cfg: ExampleConfig = ExampleConfig()) -> AnalyticConte
     """Return an :class:`AnalyticContext` with ten events and twelve activities."""
 
     events = (
-        ScheduledEvent("E0", EventTimestamp(0.0, 0.0, 0.0)),
-        ScheduledEvent("E1", EventTimestamp(2.0, 5.0, 3.0)),
-        ScheduledEvent("E2", EventTimestamp(4.0, 8.0, 6.0)),
-        ScheduledEvent("E3", EventTimestamp(6.0, 11.0, 8.0)),
-        ScheduledEvent("E4", EventTimestamp(7.0, 13.0, 9.0)),
-        ScheduledEvent("E5", EventTimestamp(10.0, 15.0, 12.0)),
-        ScheduledEvent("E6", EventTimestamp(8.0, 12.0, 9.0)),
-        ScheduledEvent("E7", EventTimestamp(11.0, 16.0, 13.0)),
-        ScheduledEvent("E8", EventTimestamp(12.0, 18.0, 14.0)),
-        ScheduledEvent("E9", EventTimestamp(14.0, 20.0, 16.0)),
+        Event("E0", EventTimestamp(0.0, 0.0, 0.0)),
+        Event("E1", EventTimestamp(2.0, 5.0, 3.0)),
+        Event("E2", EventTimestamp(4.0, 8.0, 6.0)),
+        Event("E3", EventTimestamp(6.0, 11.0, 8.0)),
+        Event("E4", EventTimestamp(7.0, 13.0, 9.0)),
+        Event("E5", EventTimestamp(10.0, 15.0, 12.0)),
+        Event("E6", EventTimestamp(8.0, 12.0, 9.0)),
+        Event("E7", EventTimestamp(11.0, 16.0, 13.0)),
+        Event("E8", EventTimestamp(12.0, 18.0, 14.0)),
+        Event("E9", EventTimestamp(14.0, 20.0, 16.0)),
     )
 
     step = cfg.step_size

--- a/example/mc_example.py
+++ b/example/mc_example.py
@@ -6,9 +6,9 @@ import numpy as np
 
 from mc_dagprop import (
     GenericDelayGenerator,
-    SimActivity,
-    SimContext,
-    SimEvent,
+    Activity,
+    DagContext,
+    Event,
     Simulator,
 )
 from ._shared import ExampleConfig, build_example_context
@@ -26,13 +26,13 @@ def build_mc_simulator(context_cfg: ExampleConfig, max_delay: float) -> Simulato
     """Return a :class:`Simulator` mirroring the analytic example."""
 
     analytic_ctx = build_example_context(context_cfg)
-    events = [SimEvent(ev.id, ev.timestamp) for ev in analytic_ctx.events]
+    events = [Event(ev.id, ev.timestamp) for ev in analytic_ctx.events]
 
-    activities: dict[tuple[int, int], tuple[int, SimActivity]] = {}
+    activities: dict[tuple[int, int], tuple[int, Activity]] = {}
     generator = GenericDelayGenerator()
 
     for (src, dst), (edge_idx, edge) in analytic_ctx.activities.items():
-        activities[(src, dst)] = (edge_idx, SimActivity(0.0, edge_idx))
+        activities[(src, dst)] = (edge_idx, Activity(0.0, edge_idx))
         pmf = edge.pmf
         generator.add_empirical_absolute(
             edge_idx,
@@ -40,7 +40,7 @@ def build_mc_simulator(context_cfg: ExampleConfig, max_delay: float) -> Simulato
             pmf.probabilities.tolist(),
         )
 
-    mc_ctx = SimContext(
+    mc_ctx = DagContext(
         events=events,
         activities=activities,
         precedence_list=analytic_ctx.precedence_list,


### PR DESCRIPTION
## Summary
- use new `Event`, `Activity`, `DagContext` classes in examples
- reference `Event` in analytic documentation

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a4a79421083229070f5ae4e7671f0