### PR TITLE
Include edge index in Activity definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ events = [
 ]
 
 activities = {
-    (0, 1): (0, Activity(minimal_duration=60.0, activity_type=1)),
+    (0, 1): Activity(idx=0, minimal_duration=60.0, activity_type=1),
 }
 
 precedence = [
@@ -160,19 +160,20 @@ Wraps a DAG node with:
 - `id`        – string key for the node  
 - `timestamp` – an `EventTimestamp` instance  
 
-### `Activity(minimal_duration: float, activity_type: int)`
+### `Activity(idx: int, minimal_duration: float, activity_type: int)`
 
 Represents an edge in the DAG:
 
-- `minimal_duration` – minimal (base) duration  
-- `activity_type`    – integer type identifier  
+- `idx`              – unique edge index
+- `minimal_duration` – minimal (base) duration
+- `activity_type`    – integer type identifier
 
 ### `DagContext(events, activities, precedence_list, max_delay)`
 
 Container for your DAG:
 
 - `events`:          `list[Event]`
-- `activities`:      `dict[(src_idx, dst_idx), (link_idx, Activity)]`
+- `activities`:      `dict[(src_idx, dst_idx), Activity]`
 - `precedence_list`: `list[(target_idx, [(pred_idx, link_idx), …])]`
 - `max_delay`:       overall cap on delay propagation
   - Can be given in any order. `Simulator` will sort topologically and raise

--- a/benchmarks/benchmark_simulator.py
+++ b/benchmarks/benchmark_simulator.py
@@ -15,7 +15,7 @@ N_NODES = 10_000
 
 def build_context() -> DagContext:
     events = [Event(str(i), EventTimestamp(float(i), 100.0 + i, 0.0)) for i in range(N_NODES)]
-    link_map = {(i, i + 1): (i, Activity(3.0 + random.random(), 1)) for i in range(N_NODES - 1)}
+    link_map = {(i, i + 1): Activity(idx=i, minimal_duration=3.0 + random.random(), activity_type=1) for i in range(N_NODES - 1)}
     precedence_list = [(i, [(i - 1, i)]) for i in range(1, N_NODES)]
     return DagContext(events=events, activities=link_map, precedence_list=precedence_list, max_delay=10.0)
 

--- a/example/mc_example.py
+++ b/example/mc_example.py
@@ -23,11 +23,11 @@ def build_mc_simulator(context_cfg: ExampleConfig, max_delay: float) -> Simulato
     analytic_ctx = build_example_context(context_cfg)
     events = [Event(ev.event_id, ev.timestamp) for ev in analytic_ctx.events]
 
-    activities: dict[tuple[int, int], tuple[int, Activity]] = {}
+    activities: dict[tuple[int, int], Activity] = {}
     generator = GenericDelayGenerator()
 
     for (src, dst), (edge_idx, edge) in analytic_ctx.activities.items():
-        activities[(src, dst)] = (edge_idx, Activity(0.0, edge_idx))
+        activities[(src, dst)] = Activity(idx=edge_idx, minimal_duration=0.0, activity_type=edge_idx)
         pmf = edge.pmf
         generator.add_empirical_absolute(ActivityType(edge_idx), pmf.values.tolist(), pmf.probabilities.tolist())
 

--- a/mc_dagprop/core.py
+++ b/mc_dagprop/core.py
@@ -27,10 +27,9 @@ class Event:
 
 @dataclass(slots=True, frozen=True)
 class Activity:
-    """Edge definition with minimal duration and type identifier."""
+    """Edge definition with index, minimal duration and type identifier."""
 
-    # FIXME: Add ActivityIndex as property to Activity -> we can clean then a lot up in cpp etc.
-    # index: ActivityIndex
+    idx: ActivityIndex
     minimal_duration: Second
     activity_type: ActivityType
 
@@ -40,7 +39,6 @@ class DagContext:
     """Container describing a DAG for simulation."""
 
     events: Sequence[Event]
-    # FIXME: inline the index of the activity in the activity itself
-    activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, Activity]]
+    activities: Mapping[tuple[EventIndex, EventIndex], Activity]
     precedence_list: Sequence[tuple[EventIndex, Sequence[tuple[EventIndex, ActivityIndex]]]]
     max_delay: Second

--- a/mc_dagprop/monte_carlo/_core.pyi
+++ b/mc_dagprop/monte_carlo/_core.pyi
@@ -34,10 +34,11 @@ class Activity(CoreActivity):
     Represents an activity (edge) in the DAG, with its minimal duration and type.
     """
 
+    idx: ActivityIndex
     minimal_duration: Second
     activity_type: ActivityType
 
-    def __init__(self, minimal_duration: Second, activity_type: ActivityType) -> None: ...
+    def __init__(self, idx: ActivityIndex, minimal_duration: Second, activity_type: ActivityType) -> None: ...
 
 class DagContext(CoreDagContext):
     """
@@ -47,14 +48,14 @@ class DagContext(CoreDagContext):
     """
 
     events: Sequence[Event]
-    activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, Activity]]
+    activities: Mapping[tuple[EventIndex, EventIndex], Activity]
     precedence_list: Sequence[tuple[EventIndex, list[tuple[EventIndex, ActivityIndex]]]]
     max_delay: Second
 
     def __init__(
         self,
         events: Sequence[Event],
-        activities: Mapping[tuple[EventIndex, EventIndex], tuple[ActivityIndex, Activity]],
+        activities: Mapping[tuple[EventIndex, EventIndex], Activity],
         precedence_list: Sequence[tuple[EventIndex, list[tuple[EventIndex, ActivityIndex]]]],
         max_delay: Second,
     ) -> None: ...

--- a/mc_dagprop/types.py
+++ b/mc_dagprop/types.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 from typing import NewType
 
-__all__ = ["Second", "ProbabilityMass", "ActivityIndex", "EventIndex", "ActivityIndex", "ActivityType", "EventId"]
+__all__ = [
+    "Second",
+    "ProbabilityMass",
+    "ActivityIndex",
+    "EventIndex",
+    "ActivityType",
+    "EventId",
+]
 
 Second = NewType("Second", float)
 ProbabilityMass = NewType("ProbabilityMass", float)
 
 ActivityIndex = NewType("ActivityIndex", int)
-
 EventIndex = NewType("EventIndex", int)
-ActivityIndex = NewType("ActivityIndex", int)
 ActivityType = NewType("ActivityType", int)
 EventId = NewType("EventId", str)

--- a/mc_dagprop/utils/demonstration.py
+++ b/mc_dagprop/utils/demonstration.py
@@ -15,7 +15,7 @@ def simulate_and_collect(
     """
     # simple 2-node DAG: A -> B
     events = [Event("A", EventTimestamp(0.0, 0.0, 0.0)), Event("B", EventTimestamp(0.0, 0.0, 0.0))]
-    activities = {(0, 1): (0, Activity(minimal_duration=base_duration, activity_type=1))}
+    activities = {(0, 1): Activity(idx=0, minimal_duration=base_duration, activity_type=1)}
     precedence = [(1, [(0, 0)])]
     ctx = DagContext(events, activities, precedence, max_delay=1e6)
 

--- a/mc_dagprop/utils/inspection.py
+++ b/mc_dagprop/utils/inspection.py
@@ -16,9 +16,10 @@ def retrieve_absolute_and_relative_delays(
     absolute_delays_by_type = defaultdict(list)
     relative_delays_by_type = defaultdict(list)
 
-    for link_index, activity in context.activities.values():
+    for activity in context.activities.values():
         a_type = activity.activity_type
         base = activity.minimal_duration
+        link_index = activity.idx
         delta = result.durations[link_index] - base
         absolute_delays_by_type[a_type].append(delta)
         if base != 0.0:

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -48,7 +48,10 @@ class TestDiscreteSimulator(unittest.TestCase):
 
         self.mc_context = DagContext(
             events=self.mc_events,
-            activities={(0, 1): (0, Activity(0.0, 1)), (1, 2): (1, Activity(0.0, 2))},
+            activities={
+                (0, 1): Activity(idx=0, minimal_duration=0.0, activity_type=1),
+                (1, 2): Activity(idx=1, minimal_duration=0.0, activity_type=2),
+            },
             precedence_list=self.precedence,
             max_delay=5.0,
         )

--- a/test/test_simulator.py
+++ b/test/test_simulator.py
@@ -20,11 +20,11 @@ class TestSimulator(unittest.TestCase):
 
         # 2 links: (src, dst) -> Activity
         self.link_map = {
-            (0, 1): (0, Activity(3.0, 1)),
-            (1, 2): (1, Activity(5.0, 1)),
-            (1, 3): (2, Activity(5.0, 1)),
-            (2, 4): (3, Activity(15.0, 2)),
-            (3, 4): (4, Activity(10.0, 3)),
+            (0, 1): Activity(idx=0, minimal_duration=3.0, activity_type=1),
+            (1, 2): Activity(idx=1, minimal_duration=5.0, activity_type=1),
+            (1, 3): Activity(idx=2, minimal_duration=5.0, activity_type=1),
+            (2, 4): Activity(idx=3, minimal_duration=15.0, activity_type=2),
+            (3, 4): Activity(idx=4, minimal_duration=10.0, activity_type=3),
         }
 
         # Precedence: node_idx ? [(pred_idx, link_idx)]
@@ -175,7 +175,10 @@ class TestSimulator(unittest.TestCase):
 class LargeScaleTest(unittest.TestCase):
     def setUp(self) -> None:
         self.events = [Event(str(i), EventTimestamp(float(i), 100.0 + i, 0.0)) for i in range(10_000)]
-        self.link_map = {(i, i + 1): (i, Activity(3.0, 1)) for i in range(9999)}
+        self.link_map = {
+            (i, i + 1): Activity(idx=i, minimal_duration=3.0, activity_type=1)
+            for i in range(9999)
+        }
         self.precedence_list = [(i, [(i - 1, i)]) for i in range(1, 10_000)]
         self.context = DagContext(
             events=self.events, activities=self.link_map, precedence_list=self.precedence_list, max_delay=10.0


### PR DESCRIPTION
## Summary
- add `idx` attribute to `Activity` dataclass
- drop ActivityIndex from `DagContext.activities` mapping
- update C++ simulator core and python stubs
- adapt utils, examples, benchmarks and tests
- update documentation

Additional fix: use ActivityIndex/ActivityType aliases in C++

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a6b1981708322b346066de07bbbbe