### PR TITLE
Consolidate core dataclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ exposes the `AnalyticPropagator`, `DiscreteSimulator` and helper classes.
 
 ### Shared components
 
-- `mc_dagprop.core` – basic dataclasses like `Event`, `EventTimestamp`, `Activity` and `DagContext`.
 - `mc_dagprop.types` – typed aliases for seconds, indices and identifiers.
 - `mc_dagprop.utils` – plotting and inspection utilities.
 

--- a/mc_dagprop/analytic/_context.py
+++ b/mc_dagprop/analytic/_context.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import IntEnum, unique
 
 import numpy as np
-from mc_dagprop.core import Event
+from mc_dagprop import Event
 from mc_dagprop.types import ActivityIndex, EventIndex, ProbabilityMass, Second
 
 from ._pmf import DiscretePMF

--- a/mc_dagprop/core.py
+++ b/mc_dagprop/core.py
@@ -1,44 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+"""Compatibility layer re-exporting the core dataclasses from the C++ module."""
 
-from .types import ActivityIndex, ActivityType, EventId, EventIndex, Second
+from .monte_carlo import Activity, DagContext, Event, EventTimestamp
 
 __all__ = ["EventTimestamp", "Event", "Activity", "DagContext"]
 
-
-@dataclass(slots=True, frozen=True)
-class EventTimestamp:
-    """Scheduling bounds and baseline timestamp for an event."""
-
-    earliest: Second
-    latest: Second
-    actual: Second
-
-
-@dataclass(slots=True, frozen=True)
-class Event:
-    """Node with identifier and timing information."""
-
-    event_id: EventId
-    timestamp: EventTimestamp
-
-
-@dataclass(slots=True, frozen=True)
-class Activity:
-    """Edge definition with index, minimal duration and type identifier."""
-
-    idx: ActivityIndex
-    minimal_duration: Second
-    activity_type: ActivityType
-
-
-@dataclass(slots=True, frozen=True)
-class DagContext:
-    """Container describing a DAG for simulation."""
-
-    events: Sequence[Event]
-    activities: Mapping[tuple[EventIndex, EventIndex], Activity]
-    precedence_list: Sequence[tuple[EventIndex, Sequence[tuple[EventIndex, ActivityIndex]]]]
-    max_delay: Second

--- a/mc_dagprop/monte_carlo/_core.pyi
+++ b/mc_dagprop/monte_carlo/_core.pyi
@@ -1,9 +1,6 @@
 # mc_dagprop/monte_carlo/_core.pyi
 from collections.abc import Collection, Iterable, Mapping, Sequence
 
-from mc_dagprop.core import Activity as CoreActivity
-from mc_dagprop.core import DagContext as CoreDagContext
-from mc_dagprop.core import Event as CoreEvent
 from mc_dagprop.types import ActivityIndex, ActivityType, EventId, EventIndex, Second
 from numpy._typing import NDArray
 
@@ -15,11 +12,11 @@ class EventTimestamp:
 
     earliest: Second
     latest: Second
-    timestamp: Second
+    actual: Second
 
-    def __init__(self, earliest: Second, latest: Second, timestamp: Second) -> None: ...
+    def __init__(self, earliest: Second, latest: Second, actual: Second) -> None: ...
 
-class Event(CoreEvent):
+class Event:
     """
     Represents an event (node) with its earliest/latest window and actual timestamp.
     """
@@ -27,9 +24,9 @@ class Event(CoreEvent):
     event_id: EventId
     timestamp: EventTimestamp
 
-    def __init__(self, id_: EventId, timestamp: "EventTimestamp") -> None: ...
+    def __init__(self, event_id: EventId, timestamp: EventTimestamp) -> None: ...
 
-class Activity(CoreActivity):
+class Activity:
     """
     Represents an activity (edge) in the DAG, with its minimal duration and type.
     """
@@ -40,7 +37,7 @@ class Activity(CoreActivity):
 
     def __init__(self, idx: ActivityIndex, minimal_duration: Second, activity_type: ActivityType) -> None: ...
 
-class DagContext(CoreDagContext):
+class DagContext:
     """
     Wraps the DAG: a list of events, activities, a precedence list and a
     max?delay. ``precedence_list`` can be in any order; ``Simulator`` sorts it


### PR DESCRIPTION
## Summary
- re-export C++ EventTimestamp/Event/Activity/DagContext for reuse
- decorate pybind11 classes as frozen dataclasses
- adapt analytic context to import from unified classes
- update stubs and docs

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a749d55cc83229907a2755c383a50