### PR TITLE
Fix packaging without copying and drop old alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ associated data structures for running Monte Carlo experiments.
 ### Full-distribution propagator (`mc_dagprop.analytic`)
 
 Python implementation that propagates discrete probability mass functions deterministically. It
-exposes the `AnalyticPropagator`, `DiscreteSimulator` and helper classes.
+exposes the `AnalyticPropagator` and helper classes.
 
 ### Shared components
 

--- a/demo/analytic.py
+++ b/demo/analytic.py
@@ -1,13 +1,13 @@
 from demo._shared import build_example_context, ExampleConfig
 
-from mc_dagprop import create_discrete_simulator
+from mc_dagprop import create_analytic_propagator
 
 
 def main() -> None:
     """Run the analytic propagation demonstration."""
 
     ctx = build_example_context(ExampleConfig())
-    sim = create_discrete_simulator(ctx)
+    sim = create_analytic_propagator(ctx)
     results = sim.run()
 
     for scheduled, result in zip(ctx.events, results):

--- a/pipeline.bat
+++ b/pipeline.bat
@@ -9,10 +9,6 @@ del /q build\*.*
 
 call poetry build || exit /b
 
-for /d %%d in (build\lib.*) do (
-    copy "%%d\mc_dagprop\monte_carlo\*_core*.so" mc_dagprop\monte_carlo\ >nul
-)
-
 for %%f in (dist\*.whl) do (
     call pip install %%f --force-reinstall || exit /b
 )

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -5,11 +5,7 @@ set -euo pipefail
 rm -rf dist/*
 rm -rf build/*
 
-
 poetry build
-
-BUILD_LIB_DIR=$(find build -type d -name 'lib.*' | head -n 1)
-cp "$BUILD_LIB_DIR/mc_dagprop/monte_carlo/"*_core*.so mc_dagprop/monte_carlo/
 
 pip install dist/mc_dagprop*.whl --force-reinstall
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,4 +158,5 @@ overgeneral-exceptions = "Exception"
 
 [tool.setuptools.packages.find]
 include = ["mc_dagprop*"]
+where = ["src"]
 

--- a/src/mc_dagprop/analytic/__init__.py
+++ b/src/mc_dagprop/analytic/__init__.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from mc_dagprop.types import ActivityIndex, EventIndex, ProbabilityMass, Second
 from ._context import AnalyticContext, OverflowRule, SimulatedEvent, UnderflowRule, AnalyticActivity
 from ._pmf import DiscretePMF
-from ._propagator import AnalyticPropagator,  create_analytic_propagator
+from ._propagator import AnalyticPropagator, create_analytic_propagator
+
 __all__ = [
     "DiscretePMF",
     "SimulatedEvent",


### PR DESCRIPTION
## Summary
- simplify build pipeline for src layout
- drop DiscreteSimulator and create_discrete_simulator alias
- update analytic demo and unit tests to call `create_analytic_propagator`
- remove obsolete compatibility note from README

## Testing
- `bash pipeline.sh`


------
https://chatgpt.com/codex/tasks/task_e_685abb63122c83229c8b0e56588be8ee