### PR TITLE
Add distribution helpers for analytic PMF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,18 @@ Configurable delay factory (one distribution per `activity_type`):
 ## Analytic Propagator
 
 You can propagate discrete delay distributions analytically using `AnalyticPropagator`.
-Define per-edge probability mass functions and build an `AnalyticContext`:
+Define per-edge probability mass functions and build an `AnalyticContext`.
+For example, a delay following an exponential distribution with mean `10` seconds
+truncated to the range `[0, 300]` on a one-second grid can be generated with
+`exponential_pmf`:
+
+```python
+from mc_dagprop.analytic import exponential_pmf
+
+delay_pmf = exponential_pmf(scale=10.0, step=1.0, start=0.0, stop=300.0)
+```
+
+You can then use this PMF in the context definition:
 
 ```python
 from mc_dagprop import (
@@ -218,7 +229,7 @@ events = (
   Event("A", EventTimestamp(0, 10, 0)),
   Event("B", EventTimestamp(0, 10, 0)),
 )
-activities = {(0, 1): (0, DiscretePMF([1.0, 2.0], [0.5, 0.5], step=1.0))}
+activities = {(0, 1): (0, delay_pmf)}
 precedence = (
   (1, ((0, 0),)),
 )

--- a/src/mc_dagprop/analytic/__init__.py
+++ b/src/mc_dagprop/analytic/__init__.py
@@ -4,6 +4,7 @@ from mc_dagprop.types import ActivityIndex, EventIndex, ProbabilityMass, Second
 from ._context import AnalyticContext, OverflowRule, SimulatedEvent, UnderflowRule, AnalyticActivity
 from ._pmf import DiscretePMF
 from ._propagator import AnalyticPropagator, create_analytic_propagator
+from .distributions import constant_pmf, empirical_pmf, exponential_pmf, gamma_pmf
 
 __all__ = [
     "DiscretePMF",
@@ -14,6 +15,10 @@ __all__ = [
     "AnalyticPropagator",
     "AnalyticActivity",
     "create_analytic_propagator",
+    "exponential_pmf",
+    "gamma_pmf",
+    "constant_pmf",
+    "empirical_pmf",
     "Second",
     "ProbabilityMass",
     "EventIndex",

--- a/src/mc_dagprop/analytic/distributions.py
+++ b/src/mc_dagprop/analytic/distributions.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+import numpy as np
+
+from mc_dagprop.types import Second
+
+from ._pmf import DiscretePMF
+
+
+def constant_pmf(value: Second, step: Second) -> DiscretePMF:
+    """Return a deterministic distribution with all mass at ``value``."""
+    pmf = DiscretePMF.delta(float(value), float(step))
+    pmf.validate()
+    pmf.validate_alignment(step)
+    return pmf
+
+
+def _regularized_gamma(shape: float, x: float) -> float:
+    """Return the regularized lower incomplete gamma function P(shape, x)."""
+    if shape <= 0.0 or x < 0.0:
+        raise ValueError("shape must be > 0 and x >= 0")
+
+    eps = 1e-12
+    max_iter = 200
+
+    gln = math.lgamma(shape)
+
+    if x == 0.0:
+        return 0.0
+
+    if x < shape + 1.0:
+        # Series expansion
+        ap = shape
+        summand = 1.0 / shape
+        result = summand
+        for _ in range(max_iter):
+            ap += 1.0
+            summand *= x / ap
+            result += summand
+            if abs(summand) < abs(result) * eps:
+                break
+        return result * math.exp(-x + shape * math.log(x) - gln)
+
+    # Continued fraction
+    b = x + 1.0 - shape
+    c = 1.0 / 1e-30
+    d = 1.0 / b
+    h = d
+    for i in range(1, max_iter + 1):
+        an = -i * (i - shape)
+        b += 2.0
+        d = an * d + b
+        if abs(d) < 1e-30:
+            d = 1e-30
+        c = b + an / c
+        if abs(c) < 1e-30:
+            c = 1e-30
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < eps:
+            break
+    return 1.0 - math.exp(-x + shape * math.log(x) - gln) * h
+
+
+def _build_probs_from_cdf(cdf_values: np.ndarray, start: Second, step: Second, stop: Second) -> np.ndarray:
+    """Return normalised probability masses from CDF samples."""
+    diffs = np.diff(cdf_values)
+    total = diffs.sum()
+    if total == 0.0:
+        raise ValueError("zero probability mass in range")
+    return diffs / total
+
+
+def exponential_pmf(scale: Second, step: Second, start: Second, stop: Second) -> DiscretePMF:
+    """Return a discretised exponential distribution.
+
+    Parameters
+    ----------
+    scale:
+        Mean of the exponential distribution.
+    step:
+        Grid spacing for the resulting PMF.
+    start, stop:
+        Range over which to keep probability mass.
+    """
+    if scale <= 0.0:
+        raise ValueError("scale must be positive")
+    if step <= 0.0:
+        raise ValueError("step must be positive")
+    if stop < start:
+        raise ValueError("stop must be greater or equal to start")
+
+    edges = np.arange(float(start), float(stop) + float(step), float(step))
+    cdf = 1.0 - np.exp(-edges / float(scale))
+    probs = _build_probs_from_cdf(cdf, start, step, stop)
+    values = edges[:-1]
+    pmf = DiscretePMF(values, probs, step=float(step))
+    pmf.validate()
+    pmf.validate_alignment(step)
+    return pmf
+
+
+def gamma_pmf(shape: float, scale: Second, step: Second, start: Second, stop: Second) -> DiscretePMF:
+    """Return a discretised gamma distribution."""
+    if shape <= 0.0 or scale <= 0.0:
+        raise ValueError("shape and scale must be positive")
+    if step <= 0.0:
+        raise ValueError("step must be positive")
+    if stop < start:
+        raise ValueError("stop must be greater or equal to start")
+
+    edges = np.arange(float(start), float(stop) + float(step), float(step))
+    cdf_vals = np.array([_regularized_gamma(shape, edge / float(scale)) for edge in edges])
+    probs = _build_probs_from_cdf(cdf_vals, start, step, stop)
+    values = edges[:-1]
+    pmf = DiscretePMF(values, probs, step=float(step))
+    pmf.validate()
+    pmf.validate_alignment(step)
+    return pmf
+
+
+def empirical_pmf(values: Iterable[Second], weights: Iterable[float], step: Second) -> DiscretePMF:
+    """Return a PMF defined by ``values`` and ``weights``."""
+    arr_values = np.array(list(values), dtype=float)
+    arr_weights = np.array(list(weights), dtype=float)
+    if arr_values.size != arr_weights.size:
+        raise ValueError("values and weights must have same length")
+    if arr_weights.sum() <= 0.0:
+        raise ValueError("weights must sum to a positive number")
+    probs = arr_weights / arr_weights.sum()
+    pmf = DiscretePMF(arr_values, probs, step=float(step))
+    pmf.validate()
+    pmf.validate_alignment(step)
+    return pmf

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy as np
+
+from mc_dagprop.analytic import (
+    constant_pmf,
+    empirical_pmf,
+    exponential_pmf,
+    gamma_pmf,
+)
+
+
+class TestDistributionHelpers(unittest.TestCase):
+    def test_constant_pmf(self) -> None:
+        pmf = constant_pmf(5.0, step=1.0)
+        pmf.validate()
+        pmf.validate_alignment(1.0)
+        self.assertTrue(np.allclose(pmf.values, [5.0]))
+        self.assertTrue(np.allclose(pmf.probabilities, [1.0]))
+
+    def test_empirical_pmf(self) -> None:
+        pmf = empirical_pmf([0.0, 1.0, 2.0], [1, 1, 2], step=1.0)
+        pmf.validate()
+        pmf.validate_alignment(1.0)
+        self.assertAlmostEqual(pmf.probabilities.sum(), 1.0, places=6)
+
+    def test_exponential_example(self) -> None:
+        pmf = exponential_pmf(scale=10.0, step=1.0, start=0.0, stop=300.0)
+        pmf.validate()
+        pmf.validate_alignment(1.0)
+        self.assertAlmostEqual(pmf.probabilities.sum(), 1.0, places=6)
+        self.assertEqual(pmf.values[0], 0.0)
+        self.assertEqual(pmf.step, 1.0)
+
+    def test_gamma_pmf(self) -> None:
+        pmf = gamma_pmf(shape=2.0, scale=2.0, step=1.0, start=0.0, stop=20.0)
+        pmf.validate()
+        pmf.validate_alignment(1.0)
+        self.assertAlmostEqual(pmf.probabilities.sum(), 1.0, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `exponential_pmf`, `gamma_pmf`, `constant_pmf`, and `empirical_pmf`
- export these helper functions from `mc_dagprop.analytic`
- document exponential PMF helper usage in README
- add unit tests for the new distribution helpers

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ade2b47d08322ae1b6a48d88f3050