### PR TITLE
Fix analytic demo alignment & test execution

### DIFF
--- a/demo/_shared.py
+++ b/demo/_shared.py
@@ -68,11 +68,25 @@ def build_example_context(cfg: ExampleConfig = ExampleConfig()) -> AnalyticConte
         ),
         (7, 5): (
             ActivityIndex(7),
-            AnalyticActivity(ActivityIndex(7), DiscretePMF(np.array([1.0, 3.0, 5.0]), np.array([0.5, 0.3, 0.2]), step)),
+            AnalyticActivity(
+                ActivityIndex(7),
+                DiscretePMF(
+                    np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+                    np.array([0.5, 0.0, 0.3, 0.0, 0.2]),
+                    step,
+                ),
+            ),
         ),
         (2, 8): (
             ActivityIndex(8),
-            AnalyticActivity(ActivityIndex(8), DiscretePMF(np.array([2.0, 4.0]), np.array([0.6, 0.4]), step)),
+            AnalyticActivity(
+                ActivityIndex(8),
+                DiscretePMF(
+                    np.array([2.0, 3.0, 4.0]),
+                    np.array([0.6, 0.0, 0.4]),
+                    step,
+                ),
+            ),
         ),
         (8, 9): (
             ActivityIndex(9),

--- a/pipeline.bat
+++ b/pipeline.bat
@@ -14,5 +14,6 @@ for %%f in (dist\*.whl) do (
 )
 
 call python demo/distribution.py || exit /b
+call python -m demo.analytic || exit /b
 
 python -m unittest discover -s test || exit /b

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -9,5 +9,7 @@ poetry build
 
 pip install dist/mc_dagprop*.whl --force-reinstall
 
+python -m demo.analytic
+
 python -m unittest discover -s test
 

--- a/test/test_analytic_demo.py
+++ b/test/test_analytic_demo.py
@@ -1,0 +1,12 @@
+import unittest
+
+from demo import analytic
+
+
+class TestAnalyticDemo(unittest.TestCase):
+    def test_demo_runs(self) -> None:
+        analytic.main()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make analytic demo PMFs use the common step size
- run analytic demo in pipeline on Linux and Windows
- add regression test ensuring analytic demo runs

## Testing
- `bash pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b0afdf58c832288a5e8e51d21d9ae