### PR TITLE
Add GitHub Actions workflow for PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,83 @@
+name: Build wheels & publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip cibuildwheel build
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp312-* cp313-*"
+          CIBW_SKIP: "pp* *-musllinux_*"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: dist/*.whl
+
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --sdist --outdir dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist


### PR DESCRIPTION
### Motivation
- Add a dedicated release workflow that builds distributions and publishes to PyPI using GitHub Actions' OIDC trusted publishing (matches the PyPI trusted publisher configuration).

### Description
- Add `.github/workflows/publish.yml` which triggers on tag pushes matching `v*` and builds wheels on `ubuntu-latest`, `windows-latest`, and `macos-latest` using Python 3.12 and `cibuildwheel`.
- The workflow also builds a source distribution (`sdist`), uploads wheel/sdist artifacts, and publishes all distributions with `pypa/gh-action-pypi-publish@release/v1` while using `environment: release` and `permissions: id-token: write` for OIDC.

### Testing
- No automated tests were executed for this change; the workflow will be exercised by GitHub Actions when a `v*` tag is pushed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af2d962e08322806807f21f9d5924)