### PR TITLE
Clarify propagation semantics; remove global max_delay; add tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ which promotes innovative studies in transport management and the future of mobi
   - Empirical absolute/relative
 - Single-run (`run(seed)`) and batched (`run_many(seeds)`) Monte Carlo APIs.
 - Shared DAG concepts (`Event`, `Activity`, `DagContext`) and unified naming.
-- Optional global `max_delay` cap available in both engines.
+- Documented backend semantics in `docs/semantics.md`, including analytic event bounds and Monte Carlo metadata treatment of `latest`.
 
-> **Note:** For Monte Carlo, configuring multiple distributions for the same
-> `activity_type` overrides previous settings. Keep exactly one distribution per type.
+> **Note:** Configuring multiple stochastic delay families for the same
+> `activity_type` is an error. Keep exactly one distribution per type.
 
 ---
 
@@ -90,7 +90,6 @@ ctx = DagContext(
   events=events,
   activities=activities,
   precedence_list=precedence,
-  max_delay=1800.0,
 )
 
 # 2) Configure a delay generator (one distribution per activity_type)
@@ -150,7 +149,6 @@ ctx = AnalyticContext(
   step=step,
   underflow_rule=UnderflowRule.TRUNCATE,
   overflow_rule=OverflowRule.TRUNCATE,
-  max_delay=None,
 )
 
 sim = create_analytic_propagator(ctx)
@@ -169,8 +167,8 @@ Notes:
   intermediates (`np.longdouble`) and a post-operation mass correction. This
   prevents tiny probabilities from being lost to cumulative floating-point
   drift in deep analytic propagation chains.
-- `max_delay` mirrors Monte Carlo semantics by capping each event at
-  `min(latest, earliest + max_delay)`.
+- The analytic backend bounds each event distribution to `[event.earliest, event.latest]`.
+- The Monte Carlo backend treats `latest` as semantic metadata and does not cap realised event times.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,16 +29,7 @@
   `MonteCarloPropagator` as the primary class name (with `Simulator` kept as a compatibility alias).
 - Added broad parity tests between Monte Carlo and analytic propagation with
   configurable tolerance thresholds and larger test networks.
-- Integrated `max_delay` semantics into both engines:
-  - Monte Carlo now caps propagated event times by
-    `event.earliest + max_delay`.
-  - Analytic propagation now supports `AnalyticContext.max_delay` with the same
-    cap, while keeping overflow handling governed by `overflow_rule`.
+- Added event-bound overflow handling for analytic propagation.
 - Improved test ergonomics so `pytest` works without explicitly setting
   `PYTHONPATH`.
 
-### Notes
-
-- `max_delay` must be non-negative for both engines.
-- Existing tests were updated to use explicit high `max_delay` values where no
-  cap should apply.

--- a/demo/distribution.py
+++ b/demo/distribution.py
@@ -17,7 +17,7 @@ def simulate_and_collect(
     events = [Event("A", EventTimestamp(0.0, 0.0, 0.0)), Event("B", EventTimestamp(0.0, 0.0, 0.0))]
     activities = {(0, 1): Activity(idx=ActivityIndex(0), minimal_duration=base_duration, activity_type=ActivityType(1))}
     precedence = [(1, [(0, 0)])]
-    ctx = DagContext(events, activities, precedence, max_delay=1e6)
+    ctx = DagContext(events, activities, precedence)
 
     gen = GenericDelayGenerator()
     if dist_name == "constant":

--- a/demo/monte_carlo.py
+++ b/demo/monte_carlo.py
@@ -7,7 +7,7 @@ import numpy as np
 from demo._shared import ExampleConfig, build_example_context
 
 from mc_dagprop import Activity, DagContext, Event, GenericDelayGenerator, Simulator
-from mc_dagprop.types import ActivityType, EventIndex, Second
+from mc_dagprop.types import ActivityType, EventIndex
 
 
 @dataclass(frozen=True)
@@ -15,10 +15,9 @@ class MonteCarloConfig(ExampleConfig):
     """Configuration for the Monte Carlo demonstration."""
 
     trials: int = 1000
-    max_delay: Second = 1800.0
 
 
-def build_mc_simulator(context_cfg: ExampleConfig, max_delay: Second) -> Simulator:
+def build_mc_simulator(context_cfg: ExampleConfig) -> Simulator:
     """Return a :class:`Simulator` mirroring the analytic example."""
 
     analytic_ctx = build_example_context(context_cfg)
@@ -36,7 +35,7 @@ def build_mc_simulator(context_cfg: ExampleConfig, max_delay: Second) -> Simulat
         generator.add_empirical_absolute(ActivityType(edge_idx), pmf.values.tolist(), pmf.probabilities.tolist())
 
     mc_ctx = DagContext(
-        events=events, activities=activities, precedence_list=analytic_ctx.precedence_list, max_delay=max_delay
+        events=events, activities=activities, precedence_list=analytic_ctx.precedence_list
     )
 
     return Simulator(mc_ctx, generator)
@@ -51,7 +50,7 @@ def run_trials(sim: Simulator, seeds: Sequence[int]) -> np.ndarray:
 
 def main() -> None:
     cfg = MonteCarloConfig()
-    sim = build_mc_simulator(cfg, cfg.max_delay)
+    sim = build_mc_simulator(cfg)
     samples = run_trials(sim, range(cfg.trials))
     analytic = build_example_context(cfg)
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -1,0 +1,43 @@
+# Propagation semantics
+
+`mc_dagprop` provides two propagation backends with deliberately different
+semantic roles.
+
+## Analytic backend
+
+The analytic propagator is a discrete-distribution implementation of the
+Büker/OnTime-style analytical delay-propagation view. It propagates probability
+mass functions (PMFs) over a DAG using marginal operations: edge delays are
+convolved with predecessor event-time PMFs, and multiple predecessors are
+combined with a marginal maximum operation.
+
+For analytic propagation, each event's `latest` timestamp is a hard upper bound.
+Analytic event distributions are bounded to `[event.earliest, event.latest]`
+according to the configured underflow and overflow rules.
+
+Reconvergent DAGs with shared stochastic ancestry can violate the independence
+assumption implicit in marginal maximum formation. In those cases, analytic and
+Monte Carlo outputs may differ. This is a documented limitation of the current
+marginal implementation, not an implementation bug.
+
+TODO: full Büker-style route-conflict handling requires conditional convolution
+rather than only marginal convolution/maximum operations. That conflict-aware
+extension is intentionally out of scope for this pass.
+
+## Monte Carlo backend
+
+The Monte Carlo propagator samples realised edge delays and propagates realised
+event times. It is a validation/reference backend for controlled cases, not a
+semantic requirement for equivalence with the analytic backend on arbitrary
+DAGs.
+
+For Monte Carlo propagation, `latest` is semantic metadata only. Realised event
+times are not capped by `latest`.
+
+## Delay-family registration
+
+Unregistered activity types are deterministic and add no stochastic extra delay:
+the activity contributes only its configured minimal duration.
+
+Each stochastic delay family may be registered at most once per activity type.
+Registering a second family for the same activity type is an error.

--- a/src/mc_dagprop/analytic/_context.py
+++ b/src/mc_dagprop/analytic/_context.py
@@ -77,9 +77,6 @@ class AnalyticContext:
         step: Discrete time step shared by all distributions.
         underflow_rule: Rule for mass below event lower bounds.
         overflow_rule: Rule for mass above event upper bounds.
-        max_delay: Optional global delay cap relative to each event's earliest
-            time. When set, each event is effectively bounded above by
-            ``min(event.latest, event.earliest + max_delay)``.
     """
 
     events: tuple[Event, ...]
@@ -88,7 +85,6 @@ class AnalyticContext:
     step: Second
     underflow_rule: UnderflowRule
     overflow_rule: OverflowRule
-    max_delay: Second | None = None
 
 
 def validate_context(context: AnalyticContext) -> None:
@@ -102,8 +98,6 @@ def validate_context(context: AnalyticContext) -> None:
 
     if context.step <= 0.0:
         raise ValueError("step_size must be positive")
-    if context.max_delay is not None and context.max_delay < 0.0:
-        raise ValueError("max_delay must be non-negative when provided")
 
     # Validate scheduled events
     for i, ev in enumerate(context.events):

--- a/src/mc_dagprop/analytic/_propagator.py
+++ b/src/mc_dagprop/analytic/_propagator.py
@@ -148,12 +148,9 @@ class AnalyticPropagator:
         return tuple(events[i] for i in range(n_events))
 
     def _event_bounds(self, earliest: Second, latest: Second) -> tuple[int, int]:
-        """Return rounded event bounds after applying context-level delay caps."""
+        """Return rounded event bounds from the scheduled event window."""
 
-        capped_upper_bound = latest
-        if self.context.max_delay is not None:
-            capped_upper_bound = min(latest, earliest + self.context.max_delay)
-        return int(np.round(earliest)), int(np.round(capped_upper_bound))
+        return int(np.round(earliest)), int(np.round(latest))
 
     def _convert_to_simulated_event(self, pmf: DiscretePMF, min_value: int, max_value: int) -> SimulatedEvent:
         """Clip pmf to [min_value, max_value] and mass-correct depending on flow rules.

--- a/src/mc_dagprop/monte_carlo/_core.cpp
+++ b/src/mc_dagprop/monte_carlo/_core.cpp
@@ -54,11 +54,9 @@ struct DagContext {
     // user provides Activity with idx property
     unordered_map<pair<EventIndex, EventIndex>, Activity> activity_map;
     vector<pair<EventIndex, Preds>> precedence_list;
-    double max_delay;
-
     DagContext(vector<Event> ev, unordered_map<pair<EventIndex, EventIndex>, Activity> am,
-               vector<pair<EventIndex, Preds>> pl, double md)
-        : events(std::move(ev)), activity_map(std::move(am)), precedence_list(std::move(pl)), max_delay(md) {}
+               vector<pair<EventIndex, Preds>> pl)
+        : events(std::move(ev)), activity_map(std::move(am)), precedence_list(std::move(pl)) {}
 };
 
 // ── Simulation Result ────────────────────────────────────────────────────
@@ -151,9 +149,15 @@ class GenericDelayGenerator {
     GenericDelayGenerator() : rng_(random_device{}()) {}
 
     void set_seed(int s) { rng_.seed(s); }
-    void add_constant(ActivityType t, double f) { dist_map_[t] = ConstantDist{f}; }
-    void add_exponential(ActivityType t, double lam, double mx) { dist_map_[t] = ExponentialDist{lam, mx}; }
+    void ensure_unregistered(ActivityType t) const {
+        if (dist_map_.count(t)) {
+            throw std::runtime_error("delay family already registered for activity type");
+        }
+    }
+    void add_constant(ActivityType t, double f) { ensure_unregistered(t); dist_map_[t] = ConstantDist{f}; }
+    void add_exponential(ActivityType t, double lam, double mx) { ensure_unregistered(t); dist_map_[t] = ExponentialDist{lam, mx}; }
     void add_gamma(ActivityType t, double k, double s, double m = numeric_limits<double>::infinity()) {
+        ensure_unregistered(t);
         dist_map_[t] = GammaDist{k, s, m};
     }
 };
@@ -196,10 +200,6 @@ public:
         if (generator.dist_map_.count(-1)) {
             throw std::runtime_error("Activity type -1 is reserved for no delay");
         }
-        if (context_.max_delay < 0.0) {
-            throw std::runtime_error("max_delay must be non-negative");
-        }
-
         // 1) Flatten distributions and build type->index map
         delay_distributions_.reserve(generator.dist_map_.size());
         int dist_counter = 0;
@@ -330,22 +330,18 @@ public:
 
         // Propagate events
         for (EventIndex event_id : event_evaluation_order_) {
-            const double earliest = context_.events[event_id].ts.earliest;
-            const double event_upper_bound = earliest + context_.max_delay;
-
             double latest = realized_times_[event_id];
             EventIndex cause = -1;
             for (size_t idx = predecessor_offsets_[event_id]; idx < predecessor_offsets_[event_id + 1]; ++idx) {
                 EventIndex src = flat_predecessor_sources_[idx];
                 ActivityIndex edge = flat_predecessor_edges_[idx];
                 double t = realized_times_[src] + actual_durations_[edge];
-                t = std::min(t, event_upper_bound);
                 if (t >= latest) {
                     latest = t;
                     cause = src;
                 }
             }
-            realized_times_[event_id] = std::min(latest, event_upper_bound);
+            realized_times_[event_id] = latest;
             causing_event_index_[event_id] = cause;
         }
 
@@ -423,22 +419,20 @@ PYBIND11_MODULE(_core, m) {
     py::class_<DagContext> ctx_cls(m, "DagContext");
     ctx_cls
         .def(py::init<vector<Event>, unordered_map<pair<EventIndex, EventIndex>, Activity>,
-                      vector<pair<EventIndex, Preds>>, double>(),
-             py::arg("events"), py::arg("activities"), py::arg("precedence_list"), py::arg("max_delay"),
-             "Wraps a DAG: events, activity_map, precedence_list, max_delay")
+                      vector<pair<EventIndex, Preds>>>(),
+             py::arg("events"), py::arg("activities"), py::arg("precedence_list"),
+             "Wraps a DAG: events, activity_map, precedence_list")
         .def_readwrite("events", &DagContext::events)
         .def_readwrite("activities", &DagContext::activity_map)
         .def_readwrite("precedence_list", &DagContext::precedence_list)
-        .def_readwrite("max_delay", &DagContext::max_delay)
         .def(
             "__repr__",
             [](const DagContext &ctx) {
                 py::object events_r = py::repr(py::cast(ctx.events));
                 py::object act_r = py::repr(py::cast(ctx.activity_map));
                 py::object preds_r = py::repr(py::cast(ctx.precedence_list));
-                return py::str(
-                           "DagContext(events={}, activities={}, precedence_list={}, max_delay={})")
-                    .format(events_r, act_r, preds_r, ctx.max_delay);
+                return py::str("DagContext(events={}, activities={}, precedence_list={})")
+                    .format(events_r, act_r, preds_r);
             },
             "Return ``repr(self)`` style string.");
 
@@ -483,7 +477,6 @@ PYBIND11_MODULE(_core, m) {
     ctx_ann["events"] = Sequence;
     ctx_ann["activities"] = Mapping;
     ctx_ann["precedence_list"] = Sequence;
-    ctx_ann["max_delay"] = Second;
     ctx_cls.attr("__annotations__") = ctx_ann;
     dataclass(ctx_cls);
 
@@ -529,6 +522,7 @@ PYBIND11_MODULE(_core, m) {
         .def(
             "add_empirical_absolute",
             [](GenericDelayGenerator &g, ActivityType activity_type, std::vector<double> values, std::vector<double> weights) {
+                g.ensure_unregistered(activity_type);
                 g.dist_map_[activity_type] = EmpiricalAbsoluteDist{std::move(values), std::move(weights)};
             },
             py::arg("activity_type"), py::arg("values"), py::arg("weights"),
@@ -536,6 +530,7 @@ PYBIND11_MODULE(_core, m) {
         .def(
             "add_empirical_relative",
             [](GenericDelayGenerator &g, ActivityType activity_type, std::vector<double> factors, std::vector<double> weights) {
+                g.ensure_unregistered(activity_type);
                 g.dist_map_[activity_type] = EmpiricalRelativeDist{std::move(factors), std::move(weights)};
             },
             py::arg("activity_type"), py::arg("factors"), py::arg("weights"),

--- a/src/mc_dagprop/monte_carlo/_core.pyi
+++ b/src/mc_dagprop/monte_carlo/_core.pyi
@@ -40,22 +40,19 @@ class Activity:
 
 class DagContext:
     """
-    Wraps the DAG: a list of events, activities, a precedence list and a
-    max?delay. ``precedence_list`` can be in any order; ``Simulator`` sorts it
+    Wraps the DAG: a list of events, activities, and a precedence list.
+    ``precedence_list`` can be in any order; ``Simulator`` sorts it
     topologically and raises ``RuntimeError`` on cycles.
     """
 
     events: Sequence[Event]
     activities: Mapping[tuple[EventIndex, EventIndex], Activity]
     precedence_list: Sequence[tuple[EventIndex, list[tuple[EventIndex, ActivityIndex]]]]
-    max_delay: Second
-
     def __init__(
         self,
         events: Sequence[Event],
         activities: Mapping[tuple[EventIndex, EventIndex], Activity],
         precedence_list: Sequence[tuple[EventIndex, Sequence[tuple[EventIndex, ActivityIndex]]]],
-        max_delay: Second,
     ) -> None: ...
 
 class SimResult:

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -75,7 +75,6 @@ class TestDiscreteSimulator(unittest.TestCase):
                 (1, 2): Activity(idx=1, minimal_duration=0.0, activity_type=2),
             },
             precedence_list=self.precedence,
-            max_delay=1e6,
         )
         gen = GenericDelayGenerator()
         gen.add_empirical_absolute(1, [1.0, 2.0], [0.5, 0.5])
@@ -130,18 +129,7 @@ class TestDiscreteSimulator(unittest.TestCase):
         with self.assertRaises(ValueError):
             create_analytic_propagator(ctx)
 
-    def test_negative_max_delay_rejected(self) -> None:
-        ctx = AnalyticContext(
-            events=self.events,
-            activities={},
-            precedence_list=(),
-            step=1,
-            underflow_rule=UnderflowRule.TRUNCATE,
-            overflow_rule=OverflowRule.TRUNCATE,
-            max_delay=-1,
-        )
-        with self.assertRaises(ValueError):
-            create_analytic_propagator(ctx)
+
 
     def test_skip_validation(self) -> None:
         act0 = AnalyticActivity(0, DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5]), step=1))

--- a/test/test_monte_carlo_extra.py
+++ b/test/test_monte_carlo_extra.py
@@ -17,7 +17,7 @@ class BaseContextMixin:
             (1, 2): Activity(idx=1, minimal_duration=2.0, activity_type=1),
         }
         precedence = [(1, [(0, 0)]), (2, [(1, 1)])]
-        return DagContext(events=events, activities=activities, precedence_list=precedence, max_delay=1e6)
+        return DagContext(events=events, activities=activities, precedence_list=precedence)
 
 
 class TestDelayDistributions(BaseContextMixin, unittest.TestCase):
@@ -64,7 +64,7 @@ class TestErrorConditions(BaseContextMixin, unittest.TestCase):
             (1, 0): Activity(idx=1, minimal_duration=1.0, activity_type=1),
         }
         precedence = [(1, [(0, 0)]), (0, [(1, 1)])]
-        context = DagContext(events=events, activities=activities, precedence_list=precedence, max_delay=1e6)
+        context = DagContext(events=events, activities=activities, precedence_list=precedence)
         gen = GenericDelayGenerator()
         gen.add_constant(1, 0.0)
         with self.assertRaises(RuntimeError):
@@ -77,18 +77,6 @@ class TestErrorConditions(BaseContextMixin, unittest.TestCase):
         with self.assertRaises(RuntimeError):
             Simulator(context, gen)
 
-    def test_negative_max_delay_rejected(self) -> None:
-        context = self.create_context()
-        invalid_context = DagContext(
-            events=context.events,
-            activities=context.activities,
-            precedence_list=context.precedence_list,
-            max_delay=-1.0,
-        )
-        gen = GenericDelayGenerator()
-        gen.add_constant(1, 0.0)
-        with self.assertRaises(RuntimeError):
-            Simulator(invalid_context, gen)
 
 
 class TestRunMany(BaseContextMixin, unittest.TestCase):

--- a/test/test_parity_suite.py
+++ b/test/test_parity_suite.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
+import pytest
 
 from mc_dagprop import (
     Activity,
@@ -76,7 +77,6 @@ def test_large_chain_parity() -> None:
             (1, 2): Activity(idx=1, minimal_duration=0.0, activity_type=2),
         },
         precedence_list=[(1, [(0, 0)]), (2, [(1, 1)])],
-        max_delay=120.0,
     )
     generator = GenericDelayGenerator()
     generator.add_empirical_absolute(1, values_a.tolist(), probs_a.tolist())
@@ -124,7 +124,6 @@ def test_large_branching_parity() -> None:
             (2, 3): Activity(idx=3, minimal_duration=0.0, activity_type=1),
         },
         precedence_list=[(1, [(0, 0)]), (2, [(0, 1)]), (3, [(1, 2), (2, 3)])],
-        max_delay=200.0,
     )
     generator = GenericDelayGenerator()
     generator.add_empirical_absolute(1, values_left.tolist(), probs_left.tolist())
@@ -137,11 +136,11 @@ def test_large_branching_parity() -> None:
 
 def test_many_links_chain_parity() -> None:
     chain_length = 100
-    max_delay = 1_000.0
+    latest_bound = 1_000.0
     delay_values = np.array([0.0, 1.0, 2.0])
     delay_probabilities = np.array([0.2, 0.5, 0.3])
 
-    events = tuple(Event(f"E{i}", EventTimestamp(0.0, max_delay, 0.0)) for i in range(chain_length + 1))
+    events = tuple(Event(f"E{i}", EventTimestamp(0.0, latest_bound, 0.0)) for i in range(chain_length + 1))
     analytic_activities: dict[tuple[int, int], tuple[int, AnalyticActivity]] = {}
     mc_activities: dict[tuple[int, int], Activity] = {}
     analytic_precedence: list[tuple[int, tuple[tuple[int, int], ...]]] = []
@@ -164,13 +163,10 @@ def test_many_links_chain_parity() -> None:
         step=1,
         underflow_rule=UnderflowRule.TRUNCATE,
         overflow_rule=OverflowRule.TRUNCATE,
-        max_delay=max_delay,
     )
     analytic_output = create_analytic_propagator(analytic_context).run()[-1].pmf
 
-    mc_context = DagContext(
-        events=list(events), activities=mc_activities, precedence_list=mc_precedence, max_delay=max_delay
-    )
+    mc_context = DagContext(events=list(events), activities=mc_activities, precedence_list=mc_precedence)
     generator = GenericDelayGenerator()
     generator.add_empirical_absolute(1, delay_values.tolist(), delay_probabilities.tolist())
     simulator = MonteCarloPropagator(mc_context, generator)
@@ -179,12 +175,11 @@ def test_many_links_chain_parity() -> None:
     _assert_distribution_parity(analytic_output, samples, ParityTolerance(probability_atol=0.03, mean_atol=0.2))
 
 
-def test_max_delay_parity_with_truncation() -> None:
+
+def test_analytic_latest_is_hard_bound() -> None:
     values = np.array([3.0, 4.0, 5.0, 6.0])
     probabilities = np.array([0.25, 0.25, 0.3, 0.2])
-    max_delay = 4.0
-
-    events = (Event("E0", EventTimestamp(10.0, 100.0, 10.0)), Event("E1", EventTimestamp(12.0, 80.0, 12.0)))
+    events = (Event("E0", EventTimestamp(10.0, 10.0, 10.0)), Event("E1", EventTimestamp(12.0, 14.0, 12.0)))
 
     analytic_context = AnalyticContext(
         events=events,
@@ -193,23 +188,90 @@ def test_max_delay_parity_with_truncation() -> None:
         step=1,
         underflow_rule=UnderflowRule.TRUNCATE,
         overflow_rule=OverflowRule.TRUNCATE,
-        max_delay=max_delay,
     )
 
     analytic_result = create_analytic_propagator(analytic_context).run()[1]
-    assert analytic_result.pmf.values.max() <= events[1].timestamp.earliest + max_delay
+    assert analytic_result.pmf.values.max() == 14.0
     assert float(analytic_result.overflow) == 0.0
+
+
+def test_monte_carlo_latest_is_semantic_metadata_only() -> None:
+    events = [Event("E0", EventTimestamp(10.0, 10.0, 10.0)), Event("E1", EventTimestamp(12.0, 14.0, 12.0))]
+    mc_context = DagContext(
+        events=events,
+        activities={(0, 1): Activity(idx=0, minimal_duration=10.0, activity_type=1)},
+        precedence_list=[(1, [(0, 0)])],
+    )
+    generator = GenericDelayGenerator()
+    generator.add_constant(1, 0.0)
+    result = MonteCarloPropagator(mc_context, generator).run(seed=1)
+
+    assert result.realized[1] == 20.0
+    assert result.realized[1] > events[1].timestamp.latest
+
+
+def test_unregistered_activity_types_are_deterministic() -> None:
+    events = [Event("E0", EventTimestamp(0.0, 100.0, 0.0)), Event("E1", EventTimestamp(0.0, 100.0, 0.0))]
+    mc_context = DagContext(
+        events=events,
+        activities={(0, 1): Activity(idx=0, minimal_duration=7.0, activity_type=99)},
+        precedence_list=[(1, [(0, 0)])],
+    )
+
+    result = MonteCarloPropagator(mc_context, GenericDelayGenerator()).run(seed=1)
+
+    assert result.durations[0] == 7.0
+    assert result.realized[1] == 7.0
+
+
+def test_duplicate_delay_family_registration_raises_error() -> None:
+    generator = GenericDelayGenerator()
+    generator.add_constant(1, 0.0)
+
+    with pytest.raises(RuntimeError):
+        generator.add_exponential(1, 1.0, 2.0)
+
+
+def test_reconvergent_shared_ancestry_documents_marginal_maximum_non_equivalence() -> None:
+    """Analytic maximum treats equal marginals as independent after a shared stochastic ancestor."""
+
+    values = np.array([0.0, 1.0])
+    probabilities = np.array([0.5, 0.5])
+    zero = DiscretePMF(np.array([0.0]), np.array([1.0]), step=1)
+    events = tuple(Event(f"E{i}", EventTimestamp(0.0, 10.0, 0.0)) for i in range(5))
+
+    analytic_context = AnalyticContext(
+        events=events,
+        activities={
+            (0, 1): (0, AnalyticActivity(0, DiscretePMF(values, probabilities, step=1))),
+            (1, 2): (1, AnalyticActivity(1, zero)),
+            (1, 3): (2, AnalyticActivity(2, zero)),
+            (2, 4): (3, AnalyticActivity(3, zero)),
+            (3, 4): (4, AnalyticActivity(4, zero)),
+        },
+        precedence_list=((1, ((0, 0),)), (2, ((1, 1),)), (3, ((1, 2),)), (4, ((2, 3), (3, 4)))),
+        step=1,
+        underflow_rule=UnderflowRule.TRUNCATE,
+        overflow_rule=OverflowRule.TRUNCATE,
+    )
+    analytic_pmf = create_analytic_propagator(analytic_context).run()[4].pmf
 
     mc_context = DagContext(
         events=list(events),
-        activities={(0, 1): Activity(idx=0, minimal_duration=0.0, activity_type=1)},
-        precedence_list=[(1, [(0, 0)])],
-        max_delay=max_delay,
+        activities={
+            (0, 1): Activity(idx=0, minimal_duration=0.0, activity_type=1),
+            (1, 2): Activity(idx=1, minimal_duration=0.0, activity_type=99),
+            (1, 3): Activity(idx=2, minimal_duration=0.0, activity_type=99),
+            (2, 4): Activity(idx=3, minimal_duration=0.0, activity_type=99),
+            (3, 4): Activity(idx=4, minimal_duration=0.0, activity_type=99),
+        },
+        precedence_list=[(1, [(0, 0)]), (2, [(1, 1)]), (3, [(1, 2)]), (4, [(2, 3), (3, 4)])],
     )
     generator = GenericDelayGenerator()
     generator.add_empirical_absolute(1, values.tolist(), probabilities.tolist())
     simulator = MonteCarloPropagator(mc_context, generator)
+    samples = np.array([simulator.run(seed).realized[4] for seed in range(12_000)])
 
-    sample_values = np.array([simulator.run(seed).realized[1] for seed in range(8_000)])
-    assert float(sample_values.max()) <= events[1].timestamp.earliest + max_delay
-    _assert_distribution_parity(analytic_result.pmf, sample_values, ParityTolerance(0.025, 0.05))
+    assert analytic_pmf.values.tolist() == [0.0, 1.0]
+    np.testing.assert_allclose(analytic_pmf.probabilities, [0.25, 0.75])
+    assert np.mean(samples == 1.0) == pytest.approx(0.5, abs=0.03)

--- a/test/test_simulator.py
+++ b/test/test_simulator.py
@@ -31,7 +31,7 @@ class TestSimulator(unittest.TestCase):
         self.precedence_list = [(1, [(0, 0)]), (2, [(1, 1)]), (3, [(1, 2)]), (4, [(2, 3), (3, 4)])]
 
         self.context = DagContext(
-            events=self.events, activities=self.link_map, precedence_list=self.precedence_list, max_delay=1e6
+            events=self.events, activities=self.link_map, precedence_list=self.precedence_list
         )
 
     def test_constant_via_generic(self):
@@ -64,7 +64,7 @@ class TestSimulator(unittest.TestCase):
     def test_unsorted_precedence_same_result(self):
         unsorted = list(reversed(self.precedence_list))
         ctx_unsorted = DagContext(
-            events=self.events, activities=self.link_map, precedence_list=unsorted, max_delay=1e6
+            events=self.events, activities=self.link_map, precedence_list=unsorted
         )
 
         gen_a = GenericDelayGenerator()
@@ -178,7 +178,7 @@ class LargeScaleTest(unittest.TestCase):
         self.link_map = {(i, i + 1): Activity(idx=i, minimal_duration=3.0, activity_type=1) for i in range(9999)}
         self.precedence_list = [(i, [(i - 1, i)]) for i in range(1, 10_000)]
         self.context = DagContext(
-            events=self.events, activities=self.link_map, precedence_list=self.precedence_list, max_delay=1e6
+            events=self.events, activities=self.link_map, precedence_list=self.precedence_list
         )
 
     def test_large_scale_simulation(self):


### PR DESCRIPTION
### Motivation

- Make the analytic/Mont e Carlo semantic differences explicit: analytic treats `latest` as a hard bound while Monte Carlo treats `latest` only as metadata.
- Remove the global `max_delay` cap from public APIs and internal propagation so event bounds are purely `[event.earliest, event.latest]` for analytic and Monte Carlo does not cap realised times.
- Enforce registration semantics for stochastic delay families and document known analytic limitations for reconvergent DAGs (conditional convolution TODO).

### Description

- Add `docs/semantics.md` documenting the Büker/OnTime-style analytic PMF propagation view, analytic hard `latest` bounds, Monte Carlo `latest` metadata semantics, deterministic behaviour for unregistered activity types, one-registration-only rule, and a TODO about conditional-convolution route-conflict handling.
- Remove `max_delay` from the analytic public context and validation and change analytic event bounds to use `[event.earliest, event.latest]` (files: `src/mc_dagprop/analytic/_context.py`, `src/mc_dagprop/analytic/_propagator.py`).
- Remove `max_delay` from the Monte Carlo API and internal propagation; Monte Carlo no longer caps realised event times (files: `src/mc_dagprop/monte_carlo/_core.cpp`, `src/mc_dagprop/monte_carlo/_core.pyi`).
- Make unregistered activity types deterministic (no extra stochastic delay) by leaving per-link duration unchanged when no distribution is registered (Monte Carlo behaviour preserved).
- Add an `ensure_unregistered` check to the Monte Carlo `GenericDelayGenerator` so registering a second stochastic family for the same `activity_type` raises a `RuntimeError` (C++ `GenericDelayGenerator`).
- Update demos, README, and release notes to remove references to `max_delay` and point to `docs/semantics.md` for semantics.
- Add and update tests to cover the new semantics and rules: analytic `latest` is a hard bound; Monte Carlo ignores `latest`; unregistered activity types are deterministic; duplicate delay-family registration raises; parity tests preserved for chain/independent-branch DAGs; reconvergent DAG test documents and asserts the known analytic/Monte Carlo difference (file: `test/test_parity_suite.py`, plus small updates to other tests and demos).

### Testing

- Ran quick static checks with `python -m py_compile` on modified modules and demos, which succeeded.
- Exercised the parity test file with `pytest test/test_parity_suite.py -q`, which passed.
- Ran the full pipeline (`bash pipeline.sh`) that builds the wheel, installs it and runs the test suite; the test run completed successfully: `63 passed` (full test suite passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eaf32aaec8322b4f738d79f78515f)