### PR TITLE
Finalize P3–P6 hardening: duplicate registration, PMF ops, clipping, docs & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package provides two propagation modes:
 - **Analytic** propagation of full discrete probability mass functions (PMFs).
 
 Both engines share the same event/activity DAG model and expose aligned naming:
-`MonteCarloPropagator` and `AnalyticPropagator`.
+`MonteCarloPropagator` and `AnalyticPropagator`. The recommended public construction path is `PropagationContext` plus `DelayFamilyRegistry`, followed by each backend's `from_context(...)` constructor.
 
 ## Background
 
@@ -32,14 +32,14 @@ which promotes innovative studies in transport management and the future of mobi
 
 - **High-performance Monte Carlo core** in C++ via pybind11.
 - **Deterministic analytic propagator** for full event-time PMFs.
-- Custom per-activity-type Monte Carlo delay distributions:
+- Custom per-activity-type stochastic extra-delay distributions:
   - Constant
-  - Exponential
+  - Exponential (`scale` is the mean)
   - Gamma
   - Empirical absolute/relative
 - Single-run (`run(seed)`) and batched (`run_many(seeds)`) Monte Carlo APIs.
 - Shared DAG concepts (`Event`, `Activity`, `DagContext`) and unified naming.
-- Documented backend semantics in `docs/semantics.md`, including analytic event bounds and Monte Carlo metadata treatment of `latest`.
+- Documented backend semantics in `docs/semantics.md`, including analytic hard event bounds, Monte Carlo metadata treatment of `latest`, clipping-policy mass behavior, and marginal propagation limitations.
 
 > **Note:** Configuring multiple stochastic delay families for the same
 > `activity_type` is an error. Keep exactly one distribution per type.
@@ -105,7 +105,7 @@ print(analytic.run()[1].pmf.values)   # full edge-increment PMF shifted by base 
 ```
 
 `Simulator` remains available as a compatibility alias of
-`MonteCarloPropagator`.
+`MonteCarloPropagator`. `max_delay` is no longer part of the public API. For exponential delay families, use `scale` as the mean; `lambda_` exists only as a deprecated compatibility alias.
 
 ---
 
@@ -169,9 +169,10 @@ Notes:
   intermediates (`np.longdouble`) and a post-operation mass correction. This
   prevents tiny probabilities from being lost to cumulative floating-point
   drift in deep analytic propagation chains.
-- The analytic backend bounds each event distribution to `[event.earliest, event.latest]`; `latest` is a hard bound.
+- The analytic backend bounds each event distribution to `[event.earliest, event.latest]`; `latest` is a hard bound. Use `step=1` for exact tests; a coarser `step=3` may be practical for examples when the timetable grid supports it.
+- Clipping policies are explicit: `TRUNCATE` moves mass to the nearest boundary and preserves total mass; `REMOVE` reports removed mass and returns an explicit sub-probability PMF; `REDISTRIBUTE` conditionalizes the retained mass.
 - The Monte Carlo backend treats `latest` as semantic metadata and does not cap realised event times.
-- Analytic propagation is marginal PMF propagation. It is not generally exact on reconvergent DAGs with shared stochastic ancestry; full Büker-style conditional convolution / route-conflict handling is intentionally out of scope.
+- Analytic propagation is marginal PMF propagation. It is not generally exact on reconvergent DAGs with shared stochastic ancestry. A low-level conditional convolution primitive is tested for small PMFs, but full Büker-style route-conflict handling, interlinking/connection modelling, train priorities, and exact joint-distribution propagation are intentionally out of scope.
 
 ---
 

--- a/demo/distribution.py
+++ b/demo/distribution.py
@@ -23,7 +23,7 @@ def simulate_and_collect(
     if dist_name == "constant":
         gen.add_constant(ActivityType(1), factor=params["factor"])
     elif dist_name == "exponential":
-        gen.add_exponential(ActivityType(1), lambda_=params["lambda"], max_scale=params["max_scale"])
+        gen.add_exponential(ActivityType(1), scale=params["scale"], max_scale=params["max_scale"])
     elif dist_name == "gamma":
         gen.add_gamma(
             ActivityType(1), shape=params["shape"], scale=params["scale"], max_scale=params.get("max_scale", 1e6)
@@ -45,9 +45,9 @@ def main() -> None:
     configs = {
         "constant": [{"factor": 1.0}, {"factor": 2.0}],
         "exponential": [
-            {"lambda": 0.1, "max_scale": 5.0},
-            {"lambda": 0.5, "max_scale": 5.0},
-            {"lambda": 1.0, "max_scale": 5.0},
+            {"scale": 0.1, "max_scale": 5.0},
+            {"scale": 0.5, "max_scale": 5.0},
+            {"scale": 1.0, "max_scale": 5.0},
         ],
         "gamma": [
             {"shape": 0.1, "scale": 2.5, "max_scale": 3.0},

--- a/demo/monte_carlo.py
+++ b/demo/monte_carlo.py
@@ -7,7 +7,7 @@ import numpy as np
 from demo._shared import ExampleConfig, build_example_context
 
 from mc_dagprop import Activity, DagContext, Event, GenericDelayGenerator, Simulator
-from mc_dagprop.types import ActivityType, EventIndex
+from mc_dagprop.types import ActivityType, EventIndex, Second
 
 
 @dataclass(frozen=True)

--- a/docs/finalization_checklist.md
+++ b/docs/finalization_checklist.md
@@ -1,0 +1,18 @@
+# Finalization checklist
+
+This note records the P3-P6 hardening status for the v0-style propagation API.
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Duplicate delay-family registration | Implemented | `DelayFamilyRegistry` and the compiled generator reject a second stochastic family for the same activity type with an error naming the activity type. |
+| Deterministic unregistered activity types | Implemented | Unregistered activity types contribute deterministic zero extra delay, so the activity increment is its minimal/base duration. |
+| `activity_type = -1` handling | Implemented | `-1` is documented as a reserved deterministic no-delay sentinel. User stochastic registration for `-1` is rejected; leaving it unregistered remains deterministic. |
+| Common frontend construction | Implemented | `PropagationContext` plus `DelayFamilyRegistry` can construct both `MonteCarloPropagator.from_context(...)` and `AnalyticPropagator.from_context(...)`. |
+| Exponential `scale` naming | Implemented | `scale` is the preferred exponential mean parameter in docs and examples. |
+| Exponential `lambda_` deprecation | Implemented with compatibility alias | `lambda_` remains available only as a deprecated compatibility alias and emits `DeprecationWarning`. |
+| Analytic hard latest | Implemented | Analytic propagation clips event PMFs to `[earliest, latest]` according to explicit clipping policies. |
+| Monte Carlo latest metadata | Implemented | Monte Carlo propagation does not cap realized times at `latest`. |
+| Discrete PMF validation | Implemented | PMFs validate finite grid-aligned support, finite non-negative probabilities, positive integer step, nonzero normalized mass by default, and explicit sub-probability use. Duplicate support is aggregated deterministically. |
+| Clipping policies | Implemented | `TRUNCATE` moves out-of-bound mass to the nearest boundary, `REMOVE` returns explicit sub-probability PMFs and records removed mass, and `REDISTRIBUTE` conditionalizes retained mass. Empty retained support under `REMOVE` is a clear error. |
+| Conditional convolution primitive | Implemented as low-level primitive | `DiscretePMF.conditional_convolve_sum_le(...)` provides exact conditional sum convolution for tests and documentation. It is intentionally not wired into the main marginal propagator. |
+| Full route-conflict handling | Documented out of scope | Büker-style route-conflict propagation, interlinking modelling, priorities, and exact joint-distribution propagation for reconvergent correlated DAGs remain follow-up model extensions. |

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -20,8 +20,10 @@ assumption implicit in marginal maximum formation. In those cases, analytic and
 Monte Carlo outputs may differ. This is a documented limitation of the current
 marginal implementation, not an implementation bug.
 
-TODO: full Büker-style route-conflict handling requires conditional convolution
-rather than only marginal convolution/maximum operations. That conflict-aware
+A low-level conditional convolution primitive is available for exact, small
+PMF calculations, but it is deliberately not wired into the main propagator.
+Full Büker-style route-conflict handling requires a complete conflict and
+interlinking model in addition to conditional convolution; that conflict-aware
 extension is intentionally out of scope for this pass.
 
 ## Monte Carlo backend
@@ -40,7 +42,10 @@ Unregistered activity types are deterministic and add no stochastic extra delay:
 the activity contributes only its configured minimal duration.
 
 Each stochastic delay family may be registered at most once per activity type.
-Registering a second family for the same activity type is an error.
+Registering a second family for the same activity type is an error. The
+activity type `-1` is reserved as an internal deterministic no-delay sentinel:
+users must not register stochastic delay families for `-1`, and an unregistered
+`-1` activity remains deterministic like any other unregistered type.
 
 ## Activity durations and discrete PMFs
 
@@ -57,3 +62,32 @@ grid-aligned integer-step values and probabilities must be finite,
 non-negative, and normalized unless a policy explicitly creates a documented
 sub-probability result. Analytic `latest` remains a hard clipping bound; Monte
 Carlo `latest` remains metadata and does not cap realised samples.
+
+
+## Clipping policies
+
+Analytic clipping policies have explicit mass semantics:
+
+- `TRUNCATE` moves mass below/above the bound to the nearest boundary bin. If the
+  boundary bin is missing it is inserted; if it already exists the mass is
+  merged. Total PMF mass is preserved.
+- `REMOVE` removes out-of-bound mass without renormalizing retained support. The
+  resulting PMF is an explicit sub-probability PMF, and removed mass is reported
+  as event underflow/overflow. If no support remains inside the event window, a
+  clear error is raised instead of returning an empty PMF.
+- `REDISTRIBUTE` removes out-of-bound mass and renormalizes/conditionalizes the
+  retained support. If no inside support exists, mass is anchored at the lower
+  bound.
+
+Use `step=1` for exact unit tests. A coarser `step=3` can be practical for
+examples or exploratory runs when that grid is appropriate for the timetable.
+
+## Reproducibility
+
+The recommended Monte Carlo reproducibility mechanism is passing `seed` to
+`MonteCarloPropagator.run(seed=...)` or a deterministic seed sequence to
+`run_many(...)`. The lower-level `GenericDelayGenerator.set_seed(...)` remains
+available for direct generator use; a per-run seed resets the propagator's
+reusable generator state for that run.
+
+`max_delay` is no longer part of the public semantics or API.

--- a/src/mc_dagprop/analytic/_pmf.py
+++ b/src/mc_dagprop/analytic/_pmf.py
@@ -117,16 +117,44 @@ class DiscretePMF:
         return m1 * m2
 
     def convolve(self, other: "DiscretePMF") -> "DiscretePMF":
-        """Convolve two PMFs using stable arithmetic and mass correction."""
-        if len(self.values) == 1:
-            pmf = DiscretePMF(other.values + self.values[0], other.probabilities * self.probabilities[0], step=self.step, allow_subprobability=True)
-        elif len(other.values) == 1:
-            pmf = DiscretePMF(self.values + other.values[0], self.probabilities * other.probabilities[0], step=self.step, allow_subprobability=True)
-        else:
-            start = self.values[0] + other.values[0]
-            probs = np.convolve(self.probabilities.astype(np.longdouble), other.probabilities.astype(np.longdouble)).astype(float)
-            values = start + self.step * np.arange(len(probs))
-            pmf = DiscretePMF(values, probs, step=self.step, allow_subprobability=True)
+        """Convolve two PMFs using stable arithmetic and exact sparse support."""
+        self_contiguous = np.allclose(np.diff(self.values), self.step, rtol=0.0, atol=1e-9) if len(self.values) > 1 else True
+        other_contiguous = np.allclose(np.diff(other.values), other.step, rtol=0.0, atol=1e-9) if len(other.values) > 1 else True
+        if self_contiguous and other_contiguous:
+            if len(self.values) == 1:
+                pmf = DiscretePMF(
+                    other.values + self.values[0],
+                    other.probabilities * self.probabilities[0],
+                    step=self.step,
+                    allow_subprobability=True,
+                )
+            elif len(other.values) == 1:
+                pmf = DiscretePMF(
+                    self.values + other.values[0],
+                    self.probabilities * other.probabilities[0],
+                    step=self.step,
+                    allow_subprobability=True,
+                )
+            else:
+                start_value = self.values[0] + other.values[0]
+                probabilities = np.convolve(
+                    self.probabilities.astype(np.longdouble),
+                    other.probabilities.astype(np.longdouble),
+                ).astype(float)
+                values = start_value + self.step * np.arange(len(probabilities))
+                pmf = DiscretePMF(values, probabilities, step=self.step, allow_subprobability=True)
+            return pmf._rescale(self._expected_mass(float(self.total_mass), float(other.total_mass)))
+
+        masses: dict[float, np.longdouble] = {}
+        for self_value, self_probability in zip(self.values, self.probabilities):
+            for other_value, other_probability in zip(other.values, other.probabilities):
+                summed_value = float(self_value + other_value)
+                masses[summed_value] = masses.get(summed_value, np.longdouble(0.0)) + (
+                    np.longdouble(self_probability) * np.longdouble(other_probability)
+                )
+        values = np.array(sorted(masses), dtype=float)
+        probabilities = np.array([masses[value] for value in values], dtype=float)
+        pmf = DiscretePMF(values, probabilities, step=self.step, allow_subprobability=True)
         return pmf._rescale(self._expected_mass(float(self.total_mass), float(other.total_mass)))
 
     def maximum(self, other: "DiscretePMF") -> "DiscretePMF":
@@ -136,13 +164,39 @@ class DiscretePMF:
         grid = np.arange(min_start, max_end + self.step, self.step)
         pmf_self = np.zeros(len(grid), dtype=np.longdouble)
         pmf_other = np.zeros(len(grid), dtype=np.longdouble)
-        off_self = int(round((self.values[0] - min_start) / self.step))
-        off_other = int(round((other.values[0] - min_start) / self.step))
-        pmf_self[off_self : off_self + len(self.probabilities)] = self.probabilities
-        pmf_other[off_other : off_other + len(other.probabilities)] = other.probabilities
+        for value, probability in zip(self.values, self.probabilities):
+            index = int(round((value - min_start) / self.step))
+            pmf_self[index] += np.longdouble(probability)
+        for value, probability in zip(other.values, other.probabilities):
+            index = int(round((value - min_start) / self.step))
+            pmf_other[index] += np.longdouble(probability)
         cdf_self = np.cumsum(pmf_self, dtype=np.longdouble)
         cdf_other = np.cumsum(pmf_other, dtype=np.longdouble)
         cdf_self_prev = np.concatenate((np.array([0.0], dtype=np.longdouble), cdf_self[:-1]))
         probs = pmf_self * cdf_other + pmf_other * cdf_self_prev
         pmf = DiscretePMF(grid, probs.astype(float), step=self.step, allow_subprobability=True)
         return pmf._rescale(self._expected_mass(float(self.total_mass), float(other.total_mass)))
+
+    def conditional_convolve_sum_le(self, other: "DiscretePMF", threshold: Second) -> "DiscretePMF":
+        """Return ``X + Y`` conditioned on ``X + Y <= threshold``.
+
+        This is a low-level primitive for documenting Büker-style conditional
+        convolution semantics. It is intentionally not wired into the main
+        marginal propagator. The returned PMF is normalized over the accepted
+        joint support.
+        """
+        values: list[float] = []
+        probabilities: list[float] = []
+        for self_value, self_probability in zip(self.values, self.probabilities):
+            for other_value, other_probability in zip(other.values, other.probabilities):
+                summed_value = float(self_value + other_value)
+                if summed_value <= threshold:
+                    values.append(summed_value)
+                    probabilities.append(float(self_probability * other_probability))
+        if not values:
+            raise ValueError("conditional convolution has empty support")
+        probability_array = np.array(probabilities, dtype=float)
+        total = probability_array.sum()
+        if total <= 0.0:
+            raise ValueError("conditional convolution has zero accepted probability mass")
+        return DiscretePMF(np.array(values, dtype=float), probability_array / total, step=self.step)

--- a/src/mc_dagprop/frontend.py
+++ b/src/mc_dagprop/frontend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 from dataclasses import dataclass
 from typing import Callable
 
@@ -42,6 +43,8 @@ class DelayFamilyRegistry:
         self._families: dict[ActivityType, _DelayFamily] = {}
 
     def _register(self, activity_type: ActivityType, family: _DelayFamily) -> None:
+        if activity_type == -1:
+            raise ValueError("activity type -1 is reserved as the deterministic no-delay sentinel and cannot be registered")
         if activity_type in self._families:
             raise ValueError(f"delay family already registered for activity type {activity_type}")
         self._families[activity_type] = family
@@ -66,12 +69,39 @@ class DelayFamilyRegistry:
             ),
         )
 
-    def add_exponential(self, activity_type: ActivityType, scale: float, max_scale: float) -> None:
+    def add_exponential(
+        self,
+        activity_type: ActivityType,
+        scale: float | None = None,
+        max_scale: float | None = None,
+        *,
+        lambda_: float | None = None,
+    ) -> None:
+        """Register an exponential stochastic extra-delay family.
+
+        ``scale`` is the exponential mean. ``lambda_`` remains as a deprecated
+        compatibility alias and is interpreted identically to ``scale``.
+        """
+        if scale is None:
+            if lambda_ is None:
+                raise TypeError("add_exponential() missing required argument: 'scale'")
+            warnings.warn(
+                "lambda_ is deprecated; use scale for the exponential mean",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            scale = lambda_
+        elif lambda_ is not None:
+            raise TypeError("use either scale or deprecated lambda_, not both")
+        if max_scale is None:
+            raise TypeError("add_exponential() missing required argument: 'max_scale'")
+        scale_value = float(scale)
+        max_scale_value = float(max_scale)
         self._register(
             activity_type,
             _DelayFamily(
-                lambda generator, t: generator.add_exponential(t, scale, max_scale),
-                lambda base, step: exponential_pmf(base * scale, step, 0, int(math.ceil(base * max_scale / step) * step)),
+                lambda generator, t: generator.add_exponential(t, scale_value, max_scale_value),
+                lambda base, step: exponential_pmf(base * scale_value, step, 0, int(math.ceil(base * max_scale_value / step) * step)),
             ),
         )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,5 +4,7 @@ import sys
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
-if str(REPOSITORY_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPOSITORY_ROOT))
+SOURCE_ROOT = REPOSITORY_ROOT / "src"
+for import_path in (REPOSITORY_ROOT, SOURCE_ROOT):
+    if str(import_path) not in sys.path:
+        sys.path.insert(0, str(import_path))

--- a/test/test_finalization.py
+++ b/test/test_finalization.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from mc_dagprop import (
+    Activity,
+    AnalyticContext,
+    AnalyticPropagator,
+    DelayFamilyRegistry,
+    Event,
+    EventTimestamp,
+    MonteCarloPropagator,
+    OverflowRule,
+    PropagationContext,
+    UnderflowRule,
+    create_analytic_propagator,
+)
+from mc_dagprop.analytic import AnalyticActivity
+from mc_dagprop.analytic._pmf import DiscretePMF
+
+
+def _context(activity_type: int = 1, latest: float = 1_000.0) -> PropagationContext:
+    return PropagationContext(
+        events=(
+            Event("a", EventTimestamp(0.0, latest, 0.0)),
+            Event("b", EventTimestamp(0.0, latest, 0.0)),
+        ),
+        activities={(0, 1): Activity(0, 10.0, activity_type)},
+        precedence_list=((1, ((0, 0),)),),
+    )
+
+
+def _clip_result(pmf: DiscretePMF, underflow_rule: UnderflowRule, overflow_rule: OverflowRule):
+    ctx = AnalyticContext(
+        events=(Event("a", EventTimestamp(0, 100, 0)), Event("b", EventTimestamp(0, 10, 0))),
+        activities={(0, 1): (0, AnalyticActivity(0, pmf))},
+        precedence_list=((1, ((0, 0),)),),
+        step=1,
+        underflow_rule=underflow_rule,
+        overflow_rule=overflow_rule,
+    )
+    return create_analytic_propagator(ctx).run()[1]
+
+
+@pytest.mark.parametrize(
+    "first,first_args,second,second_args",
+    [
+        ("add_constant", {"factor": 0.0}, "add_empirical", {"values": [0], "weights": [1]}),
+        ("add_empirical", {"values": [0], "weights": [1]}, "add_gamma", {"shape": 2.0, "scale": 1.0}),
+        ("add_gamma", {"shape": 2.0, "scale": 1.0}, "add_exponential", {"scale": 1.0, "max_scale": 2.0}),
+        ("add_exponential", {"lambda_": 1.0, "max_scale": 2.0}, "add_constant", {"factor": 0.0}),
+    ],
+)
+def test_duplicate_registration_across_family_types_and_aliases(first: str, first_args: dict[str, object], second: str, second_args: dict[str, object]) -> None:
+    registry = DelayFamilyRegistry()
+    if "lambda_" in first_args:
+        with pytest.warns(DeprecationWarning, match="lambda_"):
+            getattr(registry, first)(activity_type=5, **first_args)
+    else:
+        getattr(registry, first)(activity_type=5, **first_args)
+    with pytest.raises(ValueError, match="activity type 5"):
+        getattr(registry, second)(activity_type=5, **second_args)
+
+
+def test_activity_type_minus_one_is_reserved_for_user_registration() -> None:
+    registry = DelayFamilyRegistry()
+    with pytest.raises(ValueError, match="activity type -1"):
+        registry.add_constant(activity_type=-1, factor=0.0)
+
+
+def test_unregistered_minus_one_remains_deterministic_zero_extra_delay() -> None:
+    registry = DelayFamilyRegistry()
+    context = _context(activity_type=-1)
+    analytic = AnalyticPropagator.from_context(
+        context,
+        registry,
+        step=1,
+        underflow_rule=UnderflowRule.TRUNCATE,
+        overflow_rule=OverflowRule.TRUNCATE,
+    )
+    np.testing.assert_allclose(analytic.context.activities[(0, 1)][1].pmf.values, [10.0])
+    assert MonteCarloPropagator.from_context(context, registry).run(seed=7).durations[0] == 10.0
+
+
+def test_frontend_exponential_lambda_alias_warns() -> None:
+    registry = DelayFamilyRegistry()
+    with pytest.warns(DeprecationWarning, match="lambda_"):
+        registry.add_exponential(activity_type=1, lambda_=1.0, max_scale=2.0)
+
+
+def test_package_root_imports_work_in_subprocess() -> None:
+    code = "from mc_dagprop import PropagationContext, DelayFamilyRegistry, MonteCarloPropagator, AnalyticPropagator; print('ok')"
+    completed = subprocess.run([sys.executable, "-c", code], check=True, text=True, capture_output=True)
+    assert completed.stdout.strip() == "ok"
+
+
+def test_pmf_shift_supports_positive_and_negative_offsets() -> None:
+    pmf = DiscretePMF(np.array([0.0, 2.0]), np.array([0.25, 0.75]), step=1)
+    np.testing.assert_allclose(pmf.shift(10).values, [10.0, 12.0])
+    np.testing.assert_allclose(pmf.shift(-1).values, [-1.0, 1.0])
+
+
+def test_pmf_convolution_exact_dirac_shift_and_mass() -> None:
+    result = DiscretePMF(np.array([0.0, 1.0]), np.array([0.5, 0.5]), step=1).convolve(
+        DiscretePMF.delta(10.0, step=1)
+    )
+    np.testing.assert_allclose(result.values, [10.0, 11.0])
+    np.testing.assert_allclose(result.probabilities, [0.5, 0.5])
+    assert result.total_mass == pytest.approx(1.0)
+
+
+def test_pmf_maximum_and_dirac_lower_bound_excess() -> None:
+    result = DiscretePMF(np.array([0.0, 2.0]), np.array([0.5, 0.5]), step=1).maximum(
+        DiscretePMF(np.array([1.0, 2.0]), np.array([0.5, 0.5]), step=1)
+    )
+    np.testing.assert_allclose(result.values, [0.0, 1.0, 2.0])
+    np.testing.assert_allclose(result.probabilities, [0.0, 0.25, 0.75])
+
+    bounded = DiscretePMF(np.array([0.0, 3.0]), np.array([0.25, 0.75]), step=1).maximum(DiscretePMF.delta(2.0, step=1))
+    np.testing.assert_allclose(bounded.values, [0.0, 1.0, 2.0, 3.0])
+    np.testing.assert_allclose(bounded.probabilities, [0.0, 0.0, 0.25, 0.75])
+
+
+def test_conditional_convolution_sum_le_matches_direct_enumeration() -> None:
+    left = DiscretePMF(np.array([0.0, 1.0]), np.array([0.25, 0.75]), step=1)
+    right = DiscretePMF(np.array([0.0, 2.0]), np.array([0.5, 0.5]), step=1)
+    result = left.conditional_convolve_sum_le(right, threshold=2.0)
+    np.testing.assert_allclose(result.values, [0.0, 1.0, 2.0])
+    np.testing.assert_allclose(result.probabilities, [0.125 / 0.625, 0.375 / 0.625, 0.125 / 0.625])
+
+
+def test_truncate_remove_and_redistribute_clipping_mass_semantics() -> None:
+    pmf = DiscretePMF(np.array([-1.0, 5.0, 12.0]), np.array([0.2, 0.5, 0.3]), step=1)
+
+    truncated = _clip_result(pmf, UnderflowRule.TRUNCATE, OverflowRule.TRUNCATE)
+    np.testing.assert_allclose(truncated.pmf.values, [0.0, 5.0, 10.0])
+    np.testing.assert_allclose(truncated.pmf.probabilities, [0.2, 0.5, 0.3])
+    assert truncated.pmf.total_mass == pytest.approx(1.0)
+    assert truncated.underflow == pytest.approx(0.0)
+    assert truncated.overflow == pytest.approx(0.0)
+
+    removed = _clip_result(pmf, UnderflowRule.REMOVE, OverflowRule.REMOVE)
+    np.testing.assert_allclose(removed.pmf.values, [5.0])
+    np.testing.assert_allclose(removed.pmf.probabilities, [0.5])
+    assert removed.pmf.total_mass == pytest.approx(0.5)
+    assert removed.underflow == pytest.approx(0.2)
+    assert removed.overflow == pytest.approx(0.3)
+
+    redistributed = _clip_result(pmf, UnderflowRule.REDISTRIBUTE, OverflowRule.REDISTRIBUTE)
+    np.testing.assert_allclose(redistributed.pmf.values, [5.0])
+    np.testing.assert_allclose(redistributed.pmf.probabilities, [1.0])
+    assert redistributed.underflow == pytest.approx(0.0)
+    assert redistributed.overflow == pytest.approx(0.0)
+
+
+def test_empty_support_after_remove_raises_clear_error() -> None:
+    pmf = DiscretePMF(np.array([-2.0, 12.0]), np.array([0.5, 0.5]), step=1)
+    with pytest.raises(ValueError, match="PMF must not be empty after clipping"):
+        _clip_result(pmf, UnderflowRule.REMOVE, OverflowRule.REMOVE)
+
+
+def test_normal_frontend_propagation_is_quiet(capsys: pytest.CaptureFixture[str]) -> None:
+    registry = DelayFamilyRegistry()
+    context = _context(activity_type=99)
+    MonteCarloPropagator.from_context(context, registry).run(seed=1)
+    AnalyticPropagator.from_context(
+        context,
+        registry,
+        step=1,
+        underflow_rule=UnderflowRule.TRUNCATE,
+        overflow_rule=OverflowRule.TRUNCATE,
+    ).run()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_seeded_monte_carlo_same_seed_reproducible_and_different_seed_differs() -> None:
+    registry = DelayFamilyRegistry()
+    registry.add_empirical(activity_type=1, values=[0.0, 10.0], weights=[0.5, 0.5])
+    simulator = MonteCarloPropagator.from_context(_context(), registry)
+    assert simulator.run(seed=12).durations[0] == simulator.run(seed=12).durations[0]
+    assert {simulator.run(seed=i).durations[0] for i in range(20)} == {10.0, 20.0}


### PR DESCRIPTION
### Motivation
- Close remaining P3–P6 hardening items to produce a robust v0-style delay-propagation package covering duplicate-registration, public API consistency, PMF operation coverage, clipping semantics, and docs/examples smoke tests. 
- Preserve established P0/P1/P2 semantics: analytic `latest` is a hard bound, Monte Carlo `latest` is metadata, `max_delay` remains removed, unregistered activity types stay deterministic, and delay families model stochastic extra delay. 
- Provide a minimal, testable conditional-convolution primitive for documentation/tests without changing the main marginal propagator semantics or adding route-conflict wiring. 

### Description
- Hardened `DelayFamilyRegistry` to consistently reject duplicate stochastic family registration, emit clear errors naming the `activity_type`, and reject user registration for `activity_type = -1` as a reserved deterministic no-delay sentinel. 
- Frontend `add_exponential` now prefers `scale` (mean) and accepts a deprecated `lambda_` alias that emits a `DeprecationWarning` for compatibility while keeping `scale` as the documented parameter. 
- Improved `DiscretePMF` low-level operations: sparse-aware exact convolution for non-contiguous supports, robust maximum formation with explicit accumulation into grid bins, and a new low-level `conditional_convolve_sum_le(...)` primitive for exact small conditional-sum convolution (kept private/untethered to the propagator). 
- Finalized analytic clipping policies and semantics: `TRUNCATE` inserts/merges boundary bins and preserves total mass, `REMOVE` returns explicit sub-probability PMFs and reports removed mass (with a clear error on empty retained support), and `REDISTRIBUTE` renormalizes retained mass; docs and README updated to reflect these policies and the public construction pattern `PropagationContext` + `DelayFamilyRegistry` → backend `from_context(...)`. 
- Added tests and small infrastructure updates: new `test/test_finalization.py` covering duplicate registration (including alias cases), `activity_type=-1` behavior, PMF shift/convolve/maximum/conditional convolution, clipping-policy mass semantics and empty-support errors, quiet library behavior, and seeded Monte Carlo reproducibility; updated `test/conftest.py` to ensure source import paths for subprocess-style import checks; demos and README updated to prefer `scale`. 

### Testing
- Ran `python -m py_compile src/mc_dagprop/analytic/_context.py src/mc_dagprop/analytic/_propagator.py` with no syntax errors. 
- Ran `pytest -q` with the full suite and observed `99 passed` and 2 deprecation warnings (expected `lambda_` compatibility warnings). 
- Ran the package pipeline with `bash pipeline.sh`, which built and installed the wheel and completed the smoke/run steps included in the pipeline successfully. 
- Tests explicitly cover duplicate-registration, alias deprecation warnings, PMF operation exactness (shift/convolve/maximum/conditional), clipping-policy mass behavior, quiet propagation, and seeded Monte Carlo reproducibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51075f6bd483229cef2391171b7d8f)