### PR TITLE
Support future Python versions in 1.0.0rc2

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -47,11 +47,14 @@ jobs:
         uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: cp312-* cp313-* cp314-*
+          # requires-python supplies the lower bound. The generic selector lets
+          # future cibuildwheel releases add new stable CPython versions without
+          # another project-side allowlist change.
+          CIBW_BUILD: cp3*-*
           CIBW_BUILD_FRONTEND: build
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_SKIP: pp* *-musllinux_*
+          CIBW_SKIP: cp*t-* pp* *-musllinux_*
           CIBW_TEST_COMMAND: >-
             python -I {project}/scripts/smoke_installed_distribution.py
             --source-root {project}
@@ -95,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.12", "3.13", "3.14"]
+        python: ["3.12", "3.13", "3.14", "3.15"]
         platform: [linux-x86_64, linux-arm64, windows-amd64, macos-x86_64, macos-arm64]
         include:
           - platform: linux-x86_64

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.12", "3.13", "3.14", "3.15"]
+        python: ["3.12", "3.13", "3.14"]
         platform: [linux-x86_64, linux-arm64, windows-amd64, macos-x86_64, macos-arm64]
         include:
           - platform: linux-x86_64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,11 +67,14 @@ jobs:
         uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: cp312-* cp313-* cp314-*
+          # requires-python supplies the lower bound. The generic selector lets
+          # future cibuildwheel releases add new stable CPython versions without
+          # another project-side allowlist change.
+          CIBW_BUILD: cp3*-*
           CIBW_BUILD_FRONTEND: build
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_SKIP: pp* *-musllinux_*
+          CIBW_SKIP: cp*t-* pp* *-musllinux_*
           CIBW_TEST_COMMAND: >-
             python -I {project}/scripts/smoke_installed_distribution.py
             --source-root {project}
@@ -116,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.12", "3.13", "3.14"]
+        python: ["3.12", "3.13", "3.14", "3.15"]
         platform: [linux-x86_64, linux-arm64, windows-amd64, macos-x86_64, macos-arm64]
         include:
           - platform: linux-x86_64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.12", "3.13", "3.14", "3.15"]
+        python: ["3.12", "3.13", "3.14"]
         platform: [linux-x86_64, linux-arm64, windows-amd64, macos-x86_64, macos-arm64]
         include:
           - platform: linux-x86_64

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ which promotes innovative studies in transport management and the future of mobi
 
 ## Installation
 
-This library requires **CPython 3.12 or later**. Binary wheels are currently
-built and tested for CPython 3.12 through 3.15. Newer CPython releases are
-not rejected by package metadata and can build from the source distribution
-until their wheel builds enter the release matrix.
+This library requires **CPython 3.12 or later**. Binary wheels are selected
+with an open-ended CPython 3 pattern, while source-distribution installs are
+currently tested on CPython 3.12 through 3.14. Newer CPython releases are not
+rejected by package metadata and can build from the source distribution until
+they enter the tested release matrix.
 
 ```bash
 # with poetry

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ which promotes innovative studies in transport management and the future of mobi
 
 ## Installation
 
-This library supports **CPython 3.12, 3.13, and 3.14**.
+This library requires **CPython 3.12 or later**. Binary wheels are currently
+built and tested for CPython 3.12 through 3.15. Newer CPython releases are
+not rejected by package metadata and can build from the source distribution
+until their wheel builds enter the release matrix.
 
 ```bash
 # with poetry
@@ -59,18 +62,18 @@ pip install mc-dagprop
 ```
 
 PyPI does not select a release candidate while a stable release is available.
-Install this candidate explicitly when validating `1.0.0rc1`:
+Install this candidate explicitly when validating `1.0.0rc2`:
 
 ```bash
-pip install "mc-dagprop==1.0.0rc1"
+pip install "mc-dagprop==1.0.0rc2"
 # or
-poetry add "mc-dagprop==1.0.0rc1"
+poetry add "mc-dagprop==1.0.0rc2"
 ```
 
 Binary wheels are tested natively on Linux x86_64 and ARM64
 (`manylinux_2_28`), Windows AMD64, and macOS x86_64 and ARM64. The source
 distribution is installed and tested from outside the checkout on the same
-platform matrix and all supported Python versions.
+platform matrix and all currently maintained Python versions.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,8 @@
   declares CPython 3.12 as its minimum without rejecting later interpreters.
 - Replaces the wheel workflow's explicit CPython-version allowlist with a
   `cp3*` selector, while retaining the package minimum through
-  `requires-python`; RC2 adds ordinary CPython 3.15 to the tested wheel and
-  source-distribution matrix.
+  `requires-python`; source-distribution installs are tested through CPython
+  3.14 without rejecting later versions that are not yet available in CI.
 - Explicitly excludes free-threaded builds until their concurrency semantics
   are validated.
 - Removes the build-time setuptools upper bound so future Python source builds

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 1.0.0rc2
+
+- Removes the artificial Python `<3.15` package-metadata bound. The package now
+  declares CPython 3.12 as its minimum without rejecting later interpreters.
+- Replaces the wheel workflow's explicit CPython-version allowlist with a
+  `cp3*` selector, while retaining the package minimum through
+  `requires-python`; RC2 adds ordinary CPython 3.15 to the tested wheel and
+  source-distribution matrix.
+- Explicitly excludes free-threaded builds until their concurrency semantics
+  are validated.
+- Removes the build-time setuptools upper bound so future Python source builds
+  can select a compatible backend release.
+
 ## 1.0.0rc1
 
 This release candidate freezes the first supported public semantics and is

--- a/docs/finalization_checklist.md
+++ b/docs/finalization_checklist.md
@@ -18,7 +18,7 @@ only after the release-candidate branch satisfies every gate.
 | Distribution tests | Wheels and the source distribution install and run outside the checkout on every documented Python/platform target. |
 | Packaging and legal | The sdist contains C++ headers; wheel/sdist metadata and contents pass smoke checks; third-party notices ship in both formats. |
 | Release identity | `v<version>` exactly matches `project.version`; the check runs before publish jobs. |
-| Release sequence | Publish `1.0.0rc1`, validate its artifacts from PyPI, then decide separately whether to create the final `1.0.0` tag. |
+| Release sequence | Publish `1.0.0rc2`, validate its artifacts from PyPI, then decide separately whether to create the final `1.0.0` tag. |
 
 No migration guide is required for the pre-1.0 API because breaking cleanup is
 explicitly allowed for this release candidate.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1364,5 +1364,5 @@ plot = ["plotly"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12,<3.15"
-content-hash = "fd9a1377839180074f9377b28e0e501e74fc4feee1b0e8110b307164cade9765"
+python-versions = ">=3.12"
+content-hash = "d2954e001a98821a14674301f5d1f644db42e729817f1d5a562d6702a5d07091"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Typing :: Typed",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-dagprop"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 description = "Discrete analytic DAG propagation with Monte Carlo validation backend"
 authors = [
     { name = "Florian Flükiger", email = "flfuchs@student.ethz.ch" },
@@ -11,10 +11,11 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Typing :: Typed",
 ]
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE", "THIRD_PARTY_NOTICES.md"]
@@ -41,12 +42,12 @@ pybind11 = ">=2.13"
 pytest = "^8.3.5"
 pytest-cov = "^7.0.0"
 ruff = "0.15.6"
-setuptools = ">=77,<83"
+setuptools = ">=77"
 twine = "^6.2.0"
 
 [build-system]
 requires = [
-    "setuptools>=77,<83",
+    "setuptools>=77",
     "wheel",
     "pybind11>=2.13",
 ]

--- a/test/test_release_engineering.py
+++ b/test/test_release_engineering.py
@@ -86,7 +86,7 @@ def test_python_compatibility_has_no_artificial_upper_bound() -> None:
         workflow = (repository_root / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
         assert "CIBW_BUILD: cp3*-*" in workflow
         assert "CIBW_SKIP: cp*t-* pp* *-musllinux_*" in workflow
-        assert 'python: ["3.12", "3.13", "3.14", "3.15"]' in workflow
+        assert 'python: ["3.12", "3.13", "3.14"]' in workflow
 
 
 def test_contributor_entrypoints_use_only_the_openbus_quality_toolchain() -> None:

--- a/test/test_release_engineering.py
+++ b/test/test_release_engineering.py
@@ -70,8 +70,23 @@ def test_source_tree_type_build_dependencies_are_in_the_locked_dev_environment()
         pyproject = tomllib.load(pyproject_file)
 
     development_dependencies = pyproject["tool"]["poetry"]["group"]["dev"]["dependencies"]
-    assert development_dependencies["setuptools"] == ">=77,<83"
+    assert development_dependencies["setuptools"] == ">=77"
     assert development_dependencies["pybind11"] == ">=2.13"
+
+
+def test_python_compatibility_has_no_artificial_upper_bound() -> None:
+    repository_root = Path(__file__).resolve().parents[1]
+    with (repository_root / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    assert pyproject["project"]["requires-python"] == ">=3.12"
+    assert pyproject["build-system"]["requires"][0] == "setuptools>=77"
+
+    for workflow_name in ("build-wheels.yml", "publish.yml"):
+        workflow = (repository_root / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+        assert "CIBW_BUILD: cp3*-*" in workflow
+        assert "CIBW_SKIP: cp*t-* pp* *-musllinux_*" in workflow
+        assert 'python: ["3.12", "3.13", "3.14", "3.15"]' in workflow
 
 
 def test_contributor_entrypoints_use_only_the_openbus_quality_toolchain() -> None:


### PR DESCRIPTION
## Summary

- prepare `mc-dagprop 1.0.0rc2`
- remove the artificial `Requires-Python <3.15` upper bound
- remove the build-time setuptools upper cap
- replace the frozen wheel-version allowlist with a future-facing ordinary-CPython selector
- test source installs on CPython 3.12–3.14 without rejecting later interpreters
- exclude free-threaded builds until their concurrency contract is validated

## Root cause

The native extension has no project-side dependency on a specific CPython minor version, but RC1 encoded `>=3.12,<3.15` in package metadata and separately hard-coded `cp312`, `cp313`, and `cp314` in both wheel workflows. Pip therefore rejected Python 3.15 and later before attempting the otherwise valid source build, and new wheel targets required another allowlist edit.

RC2 keeps CPython 3.12 as the minimum, uses an open-ended `cp3*` wheel selector, validates source installs on every CPython minor currently provisioned by GitHub Actions (3.12–3.14), and permits later CPython versions to build from the sdist rather than rejecting them in metadata.

## Validation

- Ruff, Black, and BasedPyright: clean (0 errors / 0 warnings)
- pytest: 371 passed
- branch-aware Python coverage: 89.01% against the 85% gate
- `poetry check --lock`: passed
- wheel and sdist: built successfully; Twine passed
- both artifacts installed and smoke-tested outside the checkout
- built wheel metadata: `Version: 1.0.0rc2`, `Requires-Python: >=3.12`
- cibuildwheel 4.2.0 selector dry-run: ordinary CPython 3.12, 3.13, 3.14, and 3.15 only on Linux x86_64

After review and merge, create tag `v1.0.0rc2` at the merge commit. Do not create `v1.0.0`.