### PR TITLE
Prepare marginal analytic 1.0.1rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ pip install mc-dagprop
 ```
 
 PyPI does not select a release candidate while a stable release is available.
-Install this candidate explicitly when validating `1.0.0rc1`:
+Install this candidate explicitly when validating `1.0.1rc1`:
 
 ```bash
-pip install "mc-dagprop==1.0.0rc1"
+pip install "mc-dagprop==1.0.1rc1"
 # or
-poetry add "mc-dagprop==1.0.0rc1"
+poetry add "mc-dagprop==1.0.1rc1"
 ```
 
 Binary wheels are tested natively on Linux x86_64 and ARM64
@@ -188,9 +188,11 @@ Notes:
 - The analytic backend bounds each event distribution to `[event.earliest, event.latest]`; `latest` is a hard bound. Use `step=1` for exact tests; a coarser `step=3` may be practical for examples when the timetable grid supports it.
 - Clipping policies are explicit: `TRUNCATE` moves mass to the nearest boundary and preserves total mass; `REMOVE` reports removed mass and returns an explicit sub-probability PMF, including a zero-mass PMF when everything is removed; `REDISTRIBUTE` conditionalizes retained mass or anchors each outside tail at its corresponding bound when none remains.
 - The Monte Carlo backend treats `latest` as semantic metadata and does not cap realised event times.
-- Analytic construction rejects reconvergent merges whose branches share
-  stochastic activity ancestry. Use `validate_equivalence_domain(...)` before
-  relying on exact-discrete or quantized-continuous cross-backend parity.
+- Analytic construction follows the Büker--Seybold marginal approximation: it
+  combines incoming event-time PMFs as independent. This is exact for disjoint
+  stochastic ancestry and approximate when correlated branches reconverge.
+  Use `validate_exact_equivalence_domain(...)` to reject such reconvergence, or
+  `validate_equivalence_domain(...)` before relying on cross-backend parity.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## 1.0.1rc1
+
+- Aligns analytic propagation with the Büker--Seybold method by treating
+  incoming event-time marginals as independent at merges, including dependent
+  reconvergence.
+- Keeps strict stochastic-ancestry validation as an explicit diagnostic and as
+  a requirement of the qualified analytic/Monte Carlo equivalence domains.
+- Corrects floating-point PMF mass before validating convolution and maximum
+  results, preventing large analytical networks from failing on harmless
+  cumulative roundoff above unit mass.
+
 ## 1.0.0rc1
 
 This release candidate freezes the first supported public semantics and is

--- a/docs/finalization_checklist.md
+++ b/docs/finalization_checklist.md
@@ -18,7 +18,7 @@ only after the release-candidate branch satisfies every gate.
 | Distribution tests | Wheels and the source distribution install and run outside the checkout on every documented Python/platform target. |
 | Packaging and legal | The sdist contains C++ headers; wheel/sdist metadata and contents pass smoke checks; third-party notices ship in both formats. |
 | Release identity | `v<version>` exactly matches `project.version`; the check runs before publish jobs. |
-| Release sequence | Publish `1.0.0rc1`, validate its artifacts from PyPI, then decide separately whether to create the final `1.0.0` tag. |
+| Release sequence | Publish `1.0.1rc1`, validate its artifacts from PyPI, then decide separately whether to create a stable tag. |
 
 No migration guide is required for the pre-1.0 API because breaking cleanup is
 explicitly allowed for this release candidate.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -92,10 +92,20 @@ analytic grid before event propagation. It is statistical, not sample-by-
 sample. Flooring only a final event time is not equivalent on a multi-activity
 path because floor quantization is not additive.
 
-Reconvergent branches that share a stochastic ancestor are rejected by analytic
-validation. Propagating only the incoming marginals would incorrectly treat
-those correlated branches as independent. Deterministic shared ancestry remains
-valid.
+## Dependence at merges
+
+The analytic propagator follows the Büker--Seybold marginal method. It stores one
+PMF per event and combines incoming event-time PMFs as independent at a merge.
+This is exact when the branches have disjoint stochastic ancestry. If they share
+an earlier stochastic activity, their event times are correlated and the method
+deliberately discards that dependence. Monte Carlo preserves it because every
+run samples the shared activity once and reuses that realization downstream.
+
+Analytic construction therefore accepts dependent reconvergence by default.
+Call `validate_exact_equivalence_domain(...)` to reject it explicitly, or
+`validate_equivalence_domain(...)` before claiming analytic/Monte Carlo parity.
+An exact analytic treatment of dependent reconvergence would require conditional
+or joint-state distributions rather than one marginal PMF per event.
 
 ## Seeds and thread safety
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mc-dagprop"
-version = "1.0.0rc1"
+version = "1.0.1rc1"
 description = "Discrete analytic DAG propagation with Monte Carlo validation backend"
 authors = [
     { name = "Florian Flükiger", email = "flfuchs@student.ethz.ch" },

--- a/src/mc_dagprop/__init__.py
+++ b/src/mc_dagprop/__init__.py
@@ -26,6 +26,7 @@ from .analytic import (
     SimulatedEvent,
     UnderflowRule,
     create_analytic_propagator,
+    validate_exact_equivalence_domain,
 )
 from .frontend import (
     DelayFamilyRegistry,
@@ -64,5 +65,6 @@ __all__ = [
     "create_analytic_propagator",
     "monte_carlo_from_context",
     "validate_equivalence_domain",
+    "validate_exact_equivalence_domain",
     "validate_propagation_context",
 ]

--- a/src/mc_dagprop/analytic/_context.py
+++ b/src/mc_dagprop/analytic/_context.py
@@ -248,8 +248,6 @@ def validate_context(context: AnalyticContext) -> None:
     if len(topological_order) != n_events:
         raise ValueError("precedence list contains a cycle")
 
-    _validate_exact_equivalence_domain(context, topological_order)
-
 
 def _is_stochastic(pmf: DiscretePMF) -> bool:
     """Return whether ``pmf`` contains more than one possible value."""
@@ -283,10 +281,12 @@ def _validate_exact_equivalence_domain(context: AnalyticContext, topological_ord
 def validate_exact_equivalence_domain(context: AnalyticContext) -> None:
     """Validate the stochastic-independence domain required for exact propagation.
 
-    ``validate_context`` performs this check automatically. This standalone
-    helper is exposed for callers that need to state or inspect the exactness
-    contract explicitly after structural validation.
+    The analytic propagator intentionally combines incoming marginal PMFs under
+    the Büker--Seybold independence approximation. Call this helper explicitly
+    when a caller instead needs to require disjoint stochastic ancestry at every
+    merge.
     """
+    validate_context(context)
     event_count = len(context.events)
     adjacency: list[list[int]] = [[] for _ in range(event_count)]
     indegree = [0] * event_count

--- a/src/mc_dagprop/analytic/_pmf.py
+++ b/src/mc_dagprop/analytic/_pmf.py
@@ -133,12 +133,18 @@ class DiscretePMF:
             allow_subprobability=self.allow_subprobability,
         )
 
-    def _rescale(self, expected: float) -> DiscretePMF:
-        probs = self.probabilities.copy()
-        total = float(cast(np.float64, probs.sum()))
-        if total > 0 and not np.isclose(total, expected, rtol=1e-12, atol=1e-15):
-            probs *= expected / total
-        return DiscretePMF(self.values.copy(), probs, step=self.step, allow_subprobability=expected < 1.0)
+    @staticmethod
+    def _from_operation(
+        values: FloatArray, probabilities: npt.ArrayLike, step: int, expected_mass: float
+    ) -> DiscretePMF:
+        """Construct an operation result after correcting floating-point mass drift."""
+        corrected = np.asarray(probabilities, dtype=np.float64).copy()
+        total = np.sum(corrected.astype(np.longdouble), dtype=np.longdouble)
+        if total > 0.0:
+            corrected = (corrected.astype(np.longdouble) * (np.longdouble(expected_mass) / total)).astype(np.float64)
+        elif expected_mass > 0.0:
+            raise ArithmeticError("PMF operation lost all positive probability mass")
+        return DiscretePMF(values, corrected, step=step, allow_subprobability=expected_mass < 1.0)
 
     @staticmethod
     def _expected_mass(m1: float, m2: float) -> float:
@@ -170,19 +176,20 @@ class DiscretePMF:
             np.allclose(np.diff(other.values), other.step, rtol=0.0, atol=1e-9) if len(other.values) > 1 else True
         )
         if self_contiguous and other_contiguous:
+            expected_mass = self._expected_mass(float(self.total_mass), float(other.total_mass))
             if len(self.values) == 1:
-                pmf = DiscretePMF(
+                return self._from_operation(
                     other.values + cast(np.float64, self.values[0]),
                     other.probabilities * cast(np.float64, self.probabilities[0]),
-                    step=self.step,
-                    allow_subprobability=True,
+                    self.step,
+                    expected_mass,
                 )
             elif len(other.values) == 1:
-                pmf = DiscretePMF(
+                return self._from_operation(
                     self.values + cast(np.float64, other.values[0]),
                     self.probabilities * cast(np.float64, other.probabilities[0]),
-                    step=self.step,
-                    allow_subprobability=True,
+                    self.step,
+                    expected_mass,
                 )
             else:
                 start_value = float(cast(np.float64, self.values[0])) + float(cast(np.float64, other.values[0]))
@@ -190,8 +197,7 @@ class DiscretePMF:
                     self.probabilities.astype(np.longdouble), other.probabilities.astype(np.longdouble)
                 ).astype(np.float64)
                 values = start_value + self.step * np.arange(len(probabilities), dtype=np.float64)
-                pmf = DiscretePMF(values, probabilities, step=self.step, allow_subprobability=True)
-            return pmf._rescale(self._expected_mass(float(self.total_mass), float(other.total_mass)))
+                return self._from_operation(values, probabilities, self.step, expected_mass)
 
         masses: dict[float, np.longdouble] = {}
         self_values = cast(Iterable[np.float64], self.values)
@@ -207,8 +213,9 @@ class DiscretePMF:
         values = np.array(sorted(masses), dtype=np.float64)
         value_items = cast(Iterable[np.float64], values)
         probabilities = np.array([masses[float(value)] for value in value_items], dtype=np.float64)
-        pmf = DiscretePMF(values, probabilities, step=self.step, allow_subprobability=True)
-        return pmf._rescale(self._expected_mass(float(self.total_mass), float(other.total_mass)))
+        return self._from_operation(
+            values, probabilities, self.step, self._expected_mass(float(self.total_mass), float(other.total_mass))
+        )
 
     def maximum(self, other: DiscretePMF) -> DiscretePMF:
         """Return PMF of ``max(X, Y)`` with stable cumulative arithmetic."""
@@ -226,8 +233,9 @@ class DiscretePMF:
         maximum_cdf = cdf_on_support(self) * cdf_on_support(other)
         probabilities = np.diff(np.concatenate((np.array([0.0], dtype=np.longdouble), maximum_cdf)))
         probabilities = np.maximum(probabilities, np.longdouble(0.0))
-        pmf = DiscretePMF(support, probabilities.astype(float), step=self.step, allow_subprobability=True)
-        return pmf._rescale(self._expected_mass(float(self.total_mass), float(other.total_mass)))
+        return self._from_operation(
+            support, probabilities, self.step, self._expected_mass(float(self.total_mass), float(other.total_mass))
+        )
 
     def conditional_convolve_sum_le(self, other: DiscretePMF, threshold: Second) -> DiscretePMF:
         """Return ``X + Y`` conditioned on ``X + Y <= threshold``.

--- a/src/mc_dagprop/frontend.py
+++ b/src/mc_dagprop/frontend.py
@@ -10,7 +10,13 @@ from enum import StrEnum, unique
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
 
-from mc_dagprop.analytic import AnalyticActivity, AnalyticContext, OverflowRule, UnderflowRule
+from mc_dagprop.analytic import (
+    AnalyticActivity,
+    AnalyticContext,
+    OverflowRule,
+    UnderflowRule,
+    validate_exact_equivalence_domain,
+)
 from mc_dagprop.analytic.distributions import constant_pmf, empirical_pmf, exponential_pmf, gamma_pmf
 from mc_dagprop.monte_carlo import Activity, DagContext, Event, GenericDelayGenerator, MonteCarloPropagator
 from mc_dagprop.types import ActivityType, Second
@@ -445,6 +451,7 @@ def validate_equivalence_domain(
         propagator = analytic_from_context(
             context, registry, step=step, underflow_rule=UnderflowRule.REMOVE, overflow_rule=OverflowRule.REMOVE
         )
+        validate_exact_equivalence_domain(propagator.context)
         result = propagator.run()
     except (ArithmeticError, RuntimeError, TypeError, ValueError) as error:
         raise EquivalenceDomainError(str(error)) from error

--- a/test/test_parity_suite.py
+++ b/test/test_parity_suite.py
@@ -16,7 +16,7 @@ from mc_dagprop import (
     MonteCarloPropagator,
     create_analytic_propagator,
 )
-from mc_dagprop.analytic import AnalyticActivity, OverflowRule, UnderflowRule
+from mc_dagprop.analytic import AnalyticActivity, OverflowRule, UnderflowRule, validate_exact_equivalence_domain
 
 
 @dataclass(frozen=True)
@@ -231,8 +231,8 @@ def test_duplicate_delay_family_registration_raises_error() -> None:
         generator.add_exponential(1, 1.0, 2.0)
 
 
-def test_reconvergent_shared_stochastic_ancestry_is_rejected() -> None:
-    """Exact analytic propagation rejects dependent marginals at reconvergence."""
+def test_reconvergent_shared_stochastic_ancestry_uses_marginal_approximation() -> None:
+    """Propagation follows Büker--Seybold while strict validation remains available."""
 
     values = np.array([0.0, 1.0])
     probabilities = np.array([0.5, 0.5])
@@ -253,5 +253,9 @@ def test_reconvergent_shared_stochastic_ancestry_is_rejected() -> None:
         underflow_rule=UnderflowRule.TRUNCATE,
         overflow_rule=OverflowRule.TRUNCATE,
     )
+    result = create_analytic_propagator(analytic_context).run()[4].pmf
+
+    np.testing.assert_array_equal(result.values, [0.0, 1.0])
+    np.testing.assert_allclose(result.probabilities, [0.25, 0.75])
     with pytest.raises(ValueError, match="disjoint stochastic ancestry at merge 4"):
-        create_analytic_propagator(analytic_context)
+        validate_exact_equivalence_domain(analytic_context)

--- a/test/test_pmf.py
+++ b/test/test_pmf.py
@@ -34,6 +34,15 @@ class TestDiscretePMF(unittest.TestCase):
         self.assertTrue(np.isclose(float(result.total_mass), 1.0, rtol=1e-12, atol=1e-15))
         self.assertTrue(np.all(result.probabilities >= 0.0))
 
+    def test_maximum_corrects_mass_before_validating_operation_result(self) -> None:
+        accepted_roundoff = np.array([0.5, 0.5000000000009])
+        pmf = DiscretePMF(np.array([0.0, 1.0]), accepted_roundoff, step=1, allow_subprobability=True)
+
+        result = pmf.maximum(pmf)
+
+        self.assertEqual(float(result.total_mass), 1.0)
+        np.testing.assert_allclose(result.probabilities, [0.25, 0.75], rtol=0.0, atol=1.0e-12)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- align analytical DAG propagation with the Büker–Seybold marginal method: incoming event-time PMFs are combined as independent at merges, including correlated reconvergence;
- keep `validate_exact_equivalence_domain(...)` and `validate_equivalence_domain(...)` as explicit strict diagnostics;
- correct convolution/maximum probability mass before validating operation results, preventing harmless cumulative roundoff from exceeding unit mass;
- prepare the package as `mc-dagprop 1.0.1rc1`.

## Semantics

Monte Carlo preserves shared stochastic ancestry because each run samples a shared activity once. The analytical backend stores one marginal PMF per event and therefore deliberately drops this dependence at a merge, matching the Büker–Seybold approximation. Exactness is claimed only after strict ancestry/domain validation, on the configured grid and within nonbinding bounds.

## Root cause of the reported OpenBus failure

PMF operations previously constructed and validated an intermediate sub-probability PMF before applying their expected-mass correction. Two individually accepted inputs a few floating-point units above unit mass could therefore produce an intermediate merge mass outside the validation tolerance. The correction now precedes construction and validation.

## Validation

- Ruff 0.15.6: clean
- Black 25.12.0: clean
- BasedPyright 1.38.4: 0 errors, 0 warnings
- pytest: 371 passed
- branch-aware Python coverage: 89.09% against the 85% gate
- optimized Python: 371 passed
- wheel and sdist: built as `1.0.1rc1`
- Twine: both artifacts passed
- wheel and sdist: installed and smoke-tested outside the checkout

Hosted quality, C++ coverage, sanitizer, and full artifact-matrix workflows remain merge gates. After they pass and this PR is merged, create only tag `v1.0.1rc1` at the merge commit and verify the exact-tag publish workflow and PyPI candidate.