### PR TITLE
Avoid redundant PMF canonicalization in analytical propagation

### DIFF
--- a/src/mc_dagprop/analytic/_pmf.py
+++ b/src/mc_dagprop/analytic/_pmf.py
@@ -126,12 +126,7 @@ class DiscretePMF:
         if not math.isfinite(delta):
             raise ValueError("PMF shift must be finite")
         self._require_finite_support_sum(float(delta), "shift")
-        return self._from_operation(
-            self.values + delta,
-            self.probabilities,
-            self.step,
-            float(self.total_mass),
-        )
+        return self._from_operation(self.values + delta, self.probabilities, self.step, float(self.total_mass))
 
     @classmethod
     def _from_canonical(

--- a/src/mc_dagprop/analytic/_pmf.py
+++ b/src/mc_dagprop/analytic/_pmf.py
@@ -126,16 +126,32 @@ class DiscretePMF:
         if not math.isfinite(delta):
             raise ValueError("PMF shift must be finite")
         self._require_finite_support_sum(float(delta), "shift")
-        return DiscretePMF(
+        return self._from_operation(
             self.values + delta,
-            self.probabilities.copy(),
-            step=self.step,
-            allow_subprobability=self.allow_subprobability,
+            self.probabilities,
+            self.step,
+            float(self.total_mass),
         )
 
-    @staticmethod
+    @classmethod
+    def _from_canonical(
+        cls, values: npt.ArrayLike, probabilities: npt.ArrayLike, step: int, allow_subprobability: bool
+    ) -> DiscretePMF:
+        """Construct a trusted, already canonical internal operation result."""
+        result = object.__new__(cls)
+        frozen_values = np.array(values, dtype=np.float64, copy=True)
+        frozen_probabilities = np.array(probabilities, dtype=np.float64, copy=True)
+        frozen_values.setflags(write=False)
+        frozen_probabilities.setflags(write=False)
+        object.__setattr__(result, "values", frozen_values)
+        object.__setattr__(result, "probabilities", frozen_probabilities)
+        object.__setattr__(result, "step", step)
+        object.__setattr__(result, "allow_subprobability", allow_subprobability)
+        return result
+
+    @classmethod
     def _from_operation(
-        values: FloatArray, probabilities: npt.ArrayLike, step: int, expected_mass: float
+        cls, values: FloatArray, probabilities: npt.ArrayLike, step: int, expected_mass: float
     ) -> DiscretePMF:
         """Construct an operation result after correcting floating-point mass drift."""
         corrected = np.asarray(probabilities, dtype=np.float64).copy()
@@ -144,7 +160,7 @@ class DiscretePMF:
             corrected = (corrected.astype(np.longdouble) * (np.longdouble(expected_mass) / total)).astype(np.float64)
         elif expected_mass > 0.0:
             raise ArithmeticError("PMF operation lost all positive probability mass")
-        return DiscretePMF(values, corrected, step=step, allow_subprobability=expected_mass < 1.0)
+        return cls._from_canonical(values, corrected, step, allow_subprobability=expected_mass < 1.0)
 
     @staticmethod
     def _expected_mass(m1: float, m2: float) -> float:

--- a/test/test_pmf.py
+++ b/test/test_pmf.py
@@ -43,7 +43,6 @@ class TestDiscretePMF(unittest.TestCase):
         self.assertEqual(float(result.total_mass), 1.0)
         np.testing.assert_allclose(result.probabilities, [0.25, 0.75], rtol=0.0, atol=1.0e-12)
 
-
     def test_operation_results_are_immutable(self) -> None:
         pmf = DiscretePMF(np.array([0.0, 1.0]), np.array([0.4, 0.6]), step=1)
 
@@ -74,12 +73,7 @@ class TestDiscretePMF(unittest.TestCase):
                 np.testing.assert_allclose(result.probabilities, public_result.probabilities, rtol=0.0, atol=1e-15)
 
     def test_trusted_operation_preserves_subprobability_mass(self) -> None:
-        pmf = DiscretePMF(
-            np.array([0.0, 1.0]),
-            np.array([0.2, 0.3]),
-            step=1,
-            allow_subprobability=True,
-        )
+        pmf = DiscretePMF(np.array([0.0, 1.0]), np.array([0.2, 0.3]), step=1, allow_subprobability=True)
 
         shifted = pmf.shift(2.0)
         convolved = pmf.convolve(DiscretePMF.delta(0.0, step=1))
@@ -90,11 +84,7 @@ class TestDiscretePMF(unittest.TestCase):
         self.assertEqual(float(convolved.total_mass), 0.5)
 
     def test_public_constructor_still_canonicalizes_duplicates(self) -> None:
-        pmf = DiscretePMF(
-            np.array([1.0, 0.0, 1.0]),
-            np.array([0.2, 0.3, 0.5]),
-            step=1,
-        )
+        pmf = DiscretePMF(np.array([1.0, 0.0, 1.0]), np.array([0.2, 0.3, 0.5]), step=1)
 
         np.testing.assert_array_equal(pmf.values, [0.0, 1.0])
         np.testing.assert_allclose(pmf.probabilities, [0.3, 0.7], rtol=0.0, atol=1e-15)

--- a/test/test_pmf.py
+++ b/test/test_pmf.py
@@ -44,5 +44,61 @@ class TestDiscretePMF(unittest.TestCase):
         np.testing.assert_allclose(result.probabilities, [0.25, 0.75], rtol=0.0, atol=1.0e-12)
 
 
+    def test_operation_results_are_immutable(self) -> None:
+        pmf = DiscretePMF(np.array([0.0, 1.0]), np.array([0.4, 0.6]), step=1)
+
+        results = (pmf.shift(1.0), pmf.convolve(pmf), pmf.maximum(pmf))
+
+        for result in results:
+            with self.subTest(values=result.values):
+                self.assertFalse(result.values.flags.writeable)
+                self.assertFalse(result.probabilities.flags.writeable)
+                with self.assertRaises(ValueError):
+                    result.values[0] = 10.0
+                with self.assertRaises(ValueError):
+                    result.probabilities[0] = 0.0
+
+    def test_trusted_operation_results_match_public_construction(self) -> None:
+        pmf_a = DiscretePMF(np.array([0.0, 2.0]), np.array([0.25, 0.75]), step=1)
+        pmf_b = DiscretePMF(np.array([0.0, 1.0]), np.array([0.6, 0.4]), step=1)
+
+        for result in (pmf_a.shift(2.0), pmf_a.convolve(pmf_b), pmf_a.maximum(pmf_b)):
+            with self.subTest(values=result.values):
+                public_result = DiscretePMF(
+                    result.values,
+                    result.probabilities,
+                    step=result.step,
+                    allow_subprobability=result.allow_subprobability,
+                )
+                np.testing.assert_array_equal(result.values, public_result.values)
+                np.testing.assert_allclose(result.probabilities, public_result.probabilities, rtol=0.0, atol=1e-15)
+
+    def test_trusted_operation_preserves_subprobability_mass(self) -> None:
+        pmf = DiscretePMF(
+            np.array([0.0, 1.0]),
+            np.array([0.2, 0.3]),
+            step=1,
+            allow_subprobability=True,
+        )
+
+        shifted = pmf.shift(2.0)
+        convolved = pmf.convolve(DiscretePMF.delta(0.0, step=1))
+
+        self.assertTrue(shifted.allow_subprobability)
+        self.assertTrue(convolved.allow_subprobability)
+        self.assertEqual(float(shifted.total_mass), 0.5)
+        self.assertEqual(float(convolved.total_mass), 0.5)
+
+    def test_public_constructor_still_canonicalizes_duplicates(self) -> None:
+        pmf = DiscretePMF(
+            np.array([1.0, 0.0, 1.0]),
+            np.array([0.2, 0.3, 0.5]),
+            step=1,
+        )
+
+        np.testing.assert_array_equal(pmf.values, [0.0, 1.0])
+        np.testing.assert_allclose(pmf.probabilities, [0.3, 0.7], rtol=0.0, atol=1e-15)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add a private trusted construction path for already canonical PMF operation results
- use it for shifting, contiguous and sparse convolution, and maximum
- retain floating-point mass correction and immutable result arrays
- keep the public constructor's validation, sorting, and duplicate aggregation unchanged
- add regression coverage for immutability, numerical equivalence, sub-probability mass, and public duplicate canonicalization

## Root cause

Analytical propagation repeatedly passed already sorted, unique, grid-aligned operation results through the public `DiscretePMF` constructor. Its defensive validation and scalar duplicate aggregation therefore dominated runtime on dense, long-horizon grids.

## Scope

The bypass is confined to `_from_operation`, whose callers construct canonical support by invariant. `conditional_convolve_sum_le` continues to use the public constructor because it emits duplicate support values that require aggregation.

## Validation

The added tests cover the trusted-path invariants and preserve public-constructor behavior. The repository's GitHub checks will provide the full supported-Python test, lint, and typing validation.

Closes #94.
