### PR TITLE
Avoid redundant PMF canonicalization during bound clipping

### DIFF
--- a/src/mc_dagprop/analytic/_propagator.py
+++ b/src/mc_dagprop/analytic/_propagator.py
@@ -317,7 +317,8 @@ class AnalyticPropagator:
                 f"underflow={under_mass}, overflow={over_mass}"
             )
         retained_mass = float(cast(np.float64, new_probs.sum()))
-        clipped = DiscretePMF(
+        # Subsetting canonical support and inserting validated event bounds preserves canonical order and alignment.
+        clipped = DiscretePMF._from_canonical(  # pyright: ignore[reportPrivateUsage]
             new_vals,
             new_probs,
             step=pmf.step,

--- a/test/test_discrete_simulator.py
+++ b/test/test_discrete_simulator.py
@@ -1,5 +1,6 @@
 import unittest
 from dataclasses import replace
+from typing import Never
 
 import numpy as np
 import pytest
@@ -406,6 +407,31 @@ def test_rule_combinations_preserve_total_mass_and_non_negative_probabilities(
     result = _run_rule_case(underflow_rule, overflow_rule)
 
     assert np.all(result.pmf.probabilities >= 0.0)
+    assert np.isclose(float(result.pmf.total_mass + result.underflow + result.overflow), 1.0, rtol=1e-12, atol=1e-15)
+
+
+@pytest.mark.parametrize(
+    ("underflow_rule", "overflow_rule"),
+    [(under_rule, over_rule) for under_rule in UnderflowRule for over_rule in OverflowRule],
+)
+def test_bound_clipping_skips_public_canonicalization(
+    monkeypatch: pytest.MonkeyPatch, underflow_rule: UnderflowRule, overflow_rule: OverflowRule
+) -> None:
+    context = AnalyticContext(
+        (Event("event", EventTimestamp(0.0, 2.0, 0.0)),), {}, (), 1, underflow_rule, overflow_rule
+    )
+    propagator = create_analytic_propagator(context)
+    pmf = DiscretePMF(np.array([-1.0, 0.0, 1.0, 2.0, 3.0]), np.array([0.1, 0.2, 0.3, 0.25, 0.15]), step=1)
+
+    def reject_public_canonicalization(_values: np.ndarray, _probabilities: np.ndarray) -> Never:
+        raise AssertionError("bound clipping must use the trusted canonical construction path")
+
+    monkeypatch.setattr(DiscretePMF, "_canonical_arrays", staticmethod(reject_public_canonicalization))
+
+    result = propagator._convert_to_simulated_event(pmf, 0, 2)
+
+    assert not result.pmf.values.flags.writeable
+    assert not result.pmf.probabilities.flags.writeable
     assert np.isclose(float(result.pmf.total_mass + result.underflow + result.overflow), 1.0, rtol=1e-12, atol=1e-15)
 
 


### PR DESCRIPTION
## What changed

- Construct bound-clipped PMFs through the trusted canonical internal path.
- Keep the public `DiscretePMF` constructor and validation behavior unchanged.
- Cover all nine underflow/overflow policy combinations and assert that clipped arrays remain immutable, mass-accounted, and independent of public canonicalization.

## Root cause

PR #95 moved shift, convolution, and maximum results to the trusted construction path, but `AnalyticPropagator._convert_to_simulated_event` still rebuilt every clipped event through the fully validating public constructor. On dense one-second supports, that repeated sorting and scalar duplicate checking dominated analytical propagation.

Clipping starts from canonical support, retains an ordered subset, and may only insert validated grid-aligned event bounds. Its result is therefore already sorted, unique, and aligned.

## Validation

- Ruff, Black 25.12.0, and BasedPyright: passed
- Full Python suite: 384 passed
- Branch coverage: 88.94% (minimum 85%)
- README examples and all non-interactive demos: passed
- Complete 160-event, one-second-grid result digest matches rc3 exactly:
  `6a5a8da17f50eeab2b4486d964aa77776491c793d45db31ff8984b1a66ace4b1`

## Benchmark

Median of three runs of the issue #94 reproduction on CPython 3.12: 160 events, 159 60-second activities, truncated exponential factor (scale 0.1, maximum 0.5), 60-minute event horizon, and `OverflowRule.REMOVE`.

| Grid | rc3 propagation | This PR | Speedup |
|---:|---:|---:|---:|
| 1 s | 5.771 s | 0.096 s | 60.4× |
| 3 s | 1.749 s | 0.047 s | 36.9× |
| 6 s | 0.811 s | 0.042 s | 19.5× |

This is the intended performance fix for a prospective `1.0.1rc4`; it does not change the public API or PMF results.